### PR TITLE
build(client device auth plugin): build plugin artifacts as git workflow

### DIFF
--- a/.github/emqx_plugins_patch
+++ b/.github/emqx_plugins_patch
@@ -1,0 +1,10 @@
+{erlang_plugins,
+  [
+    {aws_greengrass_emqx_auth, {git, "ssh://git@github.com/aws-greengrass/aws-greengrass-emqx-mqtt", {branch, "<>"}}}
+  ]
+}.
+
+{elixir_plugins,
+  [
+  ]
+}.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Plugin build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: '*'
+
+  workflow_dispatch:
+
+jobs:
+  build-native:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-latest]
+            otp: ['24.0']
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+      - uses: wagoid/commitlint-github-action@v4
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Log cmake version
+        run: cmake --version
+
+      - name: Build the plugin's native code
+        run: |
+          mkdir _build && cd _build
+          cmake ../port_driver/
+          cmake --build .
+
+      - name: Setup emqx to build the plugin
+        run: |
+          git clone https://github.com/emqx/emqx.git; cd emqx; git reset --hard $(cat ../emqx.commit); cd ..
+          mkdir -p $GITHUB_WORKSPACE/emqx/_checkouts
+          ln -s $GITHUB_WORKSPACE $GITHUB_WORKSPACE/emqx/_checkouts/aws_greengrass_emqx_auth
+          cp .github/emqx_plugins_patch $GITHUB_WORKSPACE/emqx/lib-extra/plugins
+
+      - name: Build emqx with aws_greengrass_emqx_auth plugin
+        run: |
+          cd $GITHUB_WORKSPACE/emqx
+          EMQX_EXTRA_PLUGINS=aws_greengrass_emqx_auth make
+
+

--- a/port_driver/CMakeLists.txt
+++ b/port_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.20)
 
 project(port_driver)
 
@@ -7,9 +7,25 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -fPIC")
 
 add_subdirectory(cda_integration)
 
-cmake_path(APPEND CDA_INTEGRATION_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}" "cda_integration" "include")
-include_directories("${CDA_INTEGRATION_INCLUDES}")
+# TODO: Make work on windows
+if (UNIX)
+    execute_process (
+        COMMAND erl -noshell -eval "io:format(\"~s/../usr/include\", [code:lib_dir()])" -s erlang halt
+        OUTPUT_VARIABLE ERL_INCLUDES
+    )
+    message("Erlang include directory found: ${ERL_INCLUDES}")
 
+    execute_process(
+        COMMAND erl -noshell -eval "io:format(\"~s/../usr/lib\", [code:lib_dir()])" -s erlang halt
+        OUTPUT_VARIABLE ERL_LIBS
+    )
+    message("Erlang libs directory found: ${ERL_LIBS}")
+endif (UNIX)
+
+cmake_path(APPEND CDA_INTEGRATION_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}" "cda_integration" "include")
+include_directories("${CDA_INTEGRATION_INCLUDES}" ${ERL_INCLUDES})
+
+link_directories(${ERL_LIBS})
 add_library(${PROJECT_NAME} SHARED port_driver.c)
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 target_link_libraries(${PROJECT_NAME} PUBLIC cda_integration ei)

--- a/port_driver/cda_integration/CMakeLists.txt
+++ b/port_driver/cda_integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.20)
 
 project(cda_integration)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add git workflow for building auth plugin (native and erlang). Also made some cmake changes to support that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
