### PR TITLE
fix: exit upon failure in cmd, use console

### DIFF
--- a/patches/emqx.diff
+++ b/patches/emqx.diff
@@ -38,7 +38,7 @@
  @echo on
 -@start "%rel_name%" %werl% -boot "%boot_script%" %args%
 +@title "%rel_name%"
-+@%werl% -boot "%boot_script%" %args% || exit /b %ERRORLEVEL%
++@%werl% -boot "%boot_script%" %args% || exit /b
  @goto :eof
  
  :: Stop the Windows service
@@ -58,7 +58,7 @@
  @echo on
 -@start "bin\%rel_name% console" %werl% -boot "%boot_script%" %args%
 +@title "%rel_root_dir%\bin\%rel_name% console"
-+@%werl% -boot "%boot_script%" %args% || exit /b %ERRORLEVEL%
++@%erl_exe% -noshell -boot "%boot_script%" %args% || exit /b
  @echo emqx is started!
  @goto :eof
  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With this change, we will switch from using `start` and `stop` to using `console` and `stop`. By using console, Greengrass will be able to ensure that EMQ X is actively running (hasn't crashed) and it will also pipe the stdout/stderr into Greengrass logs (we can stop using the CRT logger if we wish)

Verified by adding a deliberate segfault and then checking the exit code in CMD. Also validated that writing to std::cerr does output into the console like it does on linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
