### PR TITLE
fix: prepend 'mqtt:' to the action to be authorized

### DIFF
--- a/bin/build.py
+++ b/bin/build.py
@@ -151,20 +151,24 @@ def main():
         print("Building EMQ X")
         if os.name == 'nt':
             print("Setting additional env var for Windows")
-            vs_paths = {"C:\\Program Files (x86)\\Microsoft Visual "
-                        "Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat",
-                        "C:\\Program Files (x86)\\Microsoft Visual "
-                        "Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat",
-                        "C:\\Program Files\\Microsoft Visual "
-                        "Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat",
-                        "C:\\Program Files\\Microsoft Visual "
-                        "Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+            vs_paths = {("C:\\Program Files (x86)\\Microsoft Visual "
+                        "Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64"),
+                        ("C:\\Program Files (x86)\\Microsoft Visual "
+                         "Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64"),
+                        ("C:\\Program Files\\Microsoft Visual "
+                         "Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64"),
+                        ("C:\\Program Files\\Microsoft Visual "
+                         "Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat", "x86_amd64"),
+                        ("C:\\Program Files (x86)\\Microsoft Visual "
+                        "Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=amd64")}
             for vs_path in vs_paths:
+                vs_arch = vs_path[1]
+                vs_path = vs_path[0]
                 if os.path.exists(vs_path):
                     break
             else:
                 raise FileNotFoundError("Unable to find where VS is installed!")
-            additional_env_var_script = f'call "{vs_path}" x86_amd64'
+            additional_env_var_script = f'call "{vs_path}" {vs_arch}'
             subprocess.check_call(f"{additional_env_var_script} && make -j", shell=True,
                                   env=dict(os.environ, EMQX_EXTRA_PLUGINS="aws_greengrass_emqx_auth"))
         else:

--- a/port_driver/cda_integration/include/cda_integration.h
+++ b/port_driver/cda_integration/include/cda_integration.h
@@ -41,8 +41,8 @@ class ClientDeviceAuthIntegration {
     subscribeToCertUpdates(std::unique_ptr<std::filesystem::path> basePath,
                            std::unique_ptr<std::function<void(GG::CertificateUpdateEvent *)>> subscription);
 
-    void handle_response_error(const std::string &action, const Aws::Eventstreamrpc::ResultType &responseType,
-                               Aws::Eventstreamrpc::OperationError *error);
+    static void handle_response_error(const std::string &action, const Aws::Eventstreamrpc::ResultType &responseType,
+                                      Aws::Eventstreamrpc::OperationError *error);
 };
 
 ClientDeviceAuthIntegration *cda_integration_init(GG::GreengrassCoreIpcClient *client);

--- a/port_driver/cda_integration/lib/cda_integration.cpp
+++ b/port_driver/cda_integration/lib/cda_integration.cpp
@@ -224,7 +224,7 @@ void cda_integration_close(ClientDeviceAuthIntegration *cda_integ) { delete cda_
 void ClientDeviceAuthIntegration::handle_response_error(const std::string &action,
                                                         const Aws::Eventstreamrpc::ResultType &responseType,
                                                         Aws::Eventstreamrpc::OperationError *error) {
-    LOG_E(CDA_INTEG_SUBJECT, FAILED_RESPONSE_TYPE_FMT, action, responseType);
+    LOG_E(CDA_INTEG_SUBJECT, FAILED_RESPONSE_TYPE_FMT, action.c_str(), responseType);
     if (responseType == OPERATION_ERROR) {
         if (error != nullptr) {
             LOG_E(CDA_INTEG_SUBJECT, FAILED_RESPONSE_MESSAGE_FMT, VERIFY_CLIENT_DEVICE_IDENTITY,

--- a/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
+++ b/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
@@ -62,7 +62,7 @@ CertWriteStatus CertificateUpdatesHandler::writeCertsToFiles(
 void CertificateUpdatesHandler::OnStreamEvent(GG::CertificateUpdateEvent *response) {
 
     LOG_I(CERT_UPDATER_SUBJECT, "Retrieving all certs...");
-    if (!response) {
+    if (response == nullptr) {
         LOG_E(CERT_UPDATER_SUBJECT, "Received CertificateUpdateEvent response was null");
         return;
     }

--- a/port_driver/port_driver.cpp
+++ b/port_driver/port_driver.cpp
@@ -292,12 +292,16 @@ static void handle_check_acl(DriverContext *context, char *buff, int index) {
         return;
     }
 
+    // Append "mqtt:" to the beginning of the action
+    auto transformedOperation = std::make_unique<std::string>("mqtt:");
+    transformedOperation->append(operation.get());
+
     LOG_D(PORT_DRIVER_SUBJECT,
           "Handling acl request with client id %s, client token %s, for topic %s, and "
           "action %s",
-          client_id.get(), auth_token.get(), resource.get(), operation.get())
-    bool result =
-        context->cda_integration->on_check_acl(client_id.get(), auth_token.get(), resource.get(), operation.get());
+          client_id.get(), auth_token.get(), resource.get(), transformedOperation->c_str())
+    bool result = context->cda_integration->on_check_acl(client_id.get(), auth_token.get(), resource.get(),
+                                                         transformedOperation->c_str());
 
     result_atom = result ? ATOMS.authorized : ATOMS.unauthorized;
     return_code = RETURN_CODE_SUCCESS;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
prepend 'mqtt:' to the action to be authorized which is what CDA requires for MQTT actions. Fixes clang-tidy issues as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
