### PR TITLE
fix: entry_size must be an int, not unsigned long with different size

### DIFF
--- a/port_driver/cda_integration/lib/ipc/ipc_wrapper.cpp
+++ b/port_driver/cda_integration/lib/ipc/ipc_wrapper.cpp
@@ -63,6 +63,6 @@ void GreengrassIPCWrapper::setAsRunning() {
     request.SetState(Aws::Greengrass::REPORTED_LIFECYCLE_STATE_RUNNING);
     auto fut = operation->Activate(request, nullptr);
     fut.wait();
-    operation->GetResult().wait_for(std::chrono::seconds(CONNECT_TIMEOUT_SECONDS));
+    operation->GetResult().get();
     operation->Close();
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change entry_size to an int which is the type required by Erlang. In `UpdateState` use `.get()` to force the future to run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
