### PR TITLE
fix: wait to kill epmd until node ping fails

### DIFF
--- a/patches/emqx.cmd.diff
+++ b/patches/emqx.cmd.diff
@@ -42,27 +42,36 @@
  @goto :eof
  
  :: Stop the Windows service
-@@ -217,6 +217,7 @@
+@@ -217,6 +224,15 @@
  :: window service?
  :: @%erlsrv% stop %service_name%
  @%escript% %nodetool% %node_type% %node_name% -setcookie %node_cookie% stop
++@IF %ERRORLEVEL% NEQ 0 (
++    @exit /b
++)
++:TryPinging
++@%escript% %nodetool% ping %node_type% "%node_name%" -setcookie "%node_cookie%"
++@IF %ERRORLEVEL% EQU 0 (
++    @goto TryPinging
++)
 +@%epmd% -kill
  @goto :eof
-
+ 
  :: Relup and reldown
-@@ -237,9 +244,9 @@
+@@ -237,10 +253,9 @@
  @call :generate_app_config
  @set args=%sys_config% %generated_config_args% -mnesia dir '%mnesia_dir%'
  @echo off
 -cd /d %rel_root_dir%
  @echo on
 -@start "bin\%rel_name% console" %werl% -boot "%boot_script%" %args%
+-@echo emqx is started!
 +@title "%rel_root_dir%\bin\%rel_name% console"
 +@%erl_exe% -noshell -boot "%boot_script%" %args% || exit /b
- @echo emqx is started!
  @goto :eof
  
-@@ -255,7 +262,7 @@
+ :: Ping the running node
+@@ -255,7 +270,7 @@
  
  :: Attach to a running node
  :attach
@@ -71,7 +80,7 @@
  @start "%node_name% attach" %werl% -boot "%clean_boot_script%" ^
    -remsh %node_name% %node_type% console_%node_name% -setcookie %node_cookie%
  @goto :eof
-@@ -264,4 +271,3 @@
+@@ -264,4 +279,3 @@
  :set_trim
  @set %1=%2
  @goto :eof


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates the `stop` cmd command with the following so that we will ping the node until it is dead, and then attempt to kill epmd. This gives us a better chance of success and should block until EMQ X has actually stopped, not just that we asked it to stop.

```batch
@%escript% %nodetool% %node_type% %node_name% -setcookie %node_cookie% stop
@IF %ERRORLEVEL% NEQ 0 (
@    exit /b
)
:TryPinging
@%escript% %nodetool% ping %node_type% "%node_name%" -setcookie "%node_cookie%"
@IF %ERRORLEVEL% EQU 0 (
@    @goto TryPinging
)
@%epmd% -kill
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
