### PR TITLE
chore: prevent build from running in echo command

### DIFF
--- a/gdk-build.sh
+++ b/gdk-build.sh
@@ -6,7 +6,7 @@ COMPONENT_NAME='aws.greengrass.clientdevices.mqtt.Emqx'
 VERSION='NEXT_PATCH'
 
 # Skip build as it is expensive. Just log instead. For now.
-echo "To build, first run `python3 -u -m bin`
+echo "To build, first run \"python3 -u -m bin\""
 #python3 -u -m bin
 
 mkdir -p greengrass-build/artifacts/${COMPONENT_NAME}/${VERSION}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prevent unwanted build from kicking off during `gdk component publish`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
