### PR TITLE
chore: add emqx env vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,13 @@ USER emqx
 
 VOLUME ["/opt/emqx/log", "/opt/emqx/data"]
 
+# Set env variables for docker container
+ENV EMQX_LOG__DIR="/opt/emqx/log"
+ENV EMQX_NODE__DATA_DIR="/opt/emqx/data"
+ENV EMQX_LISTENER__SSL__EXTERNAL__KEYFILE="/opt/emqx/data/key.pem"
+ENV EMQX_LISTENER__SSL__EXTERNAL__CERTFILE="/opt/emqx/data/cert.pem"
+ENV EMQX_LISTENER__SSL__EXTERNAL__CACERTFILE="/opt/emqx/data/cacert.pem"
+
 # emqx will occupy these port:
 # - 8883 port for MQTT(SSL)
 EXPOSE 8883


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add emqx environment vars to Dockerfile. These vars will be available inside the container when it is started

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
