### PR TITLE
feat(config): enable configuration via environment variables in Windows

### DIFF
--- a/bin/build.py
+++ b/bin/build.py
@@ -205,6 +205,7 @@ def main():
             add[f"emqx/lib/aws_greengrass_emqx_auth-1.0.0/priv/msvcp140.dll"] = "patches/msvcp140.dll"
             add[f"emqx/lib/aws_greengrass_emqx_auth-1.0.0/priv/vcruntime140.dll"] = "patches/vcruntime140.dll"
             add[f"emqx/lib/aws_greengrass_emqx_auth-1.0.0/priv/vcruntime140_1.dll"] = "patches/vcruntime140_1.dll"
+            add["emqx/bin/copy_config.cmd"] = "patches/copy_config.cmd"
         do_patch("build/emqx.zip", erts_version=erts_version, add=add)
 
     os.chdir(current_abs_path)

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -5,7 +5,7 @@
       "version": "NEXT_PATCH",
       "build": {
         "build_system": "custom",
-        "custom_build_command" : "./gdk-build.sh"
+        "custom_build_command" : "sh -c ./gdk-build.sh"
       },
       "publish": {
         "bucket": "gg-dev-artifacts",

--- a/patches/copy_config.cmd
+++ b/patches/copy_config.cmd
@@ -1,0 +1,25 @@
+@echo off
+
+:: Copy default config file into work directory
+set script_dir=%~dp0
+for %%A in ("%script_dir%\..") do @(
+    set rel_root_dir=%%~fA
+)
+copy /d /y %rel_root_dir%\etc\emqx.conf emqx.conf
+set EMQX_NODE__EMQX_CONF=%CD%\emqx.conf
+
+:: Must use delayed expansion and !variable! for multi-line variable support
+setlocal EnableDelayedExpansion
+
+:: If the user provides us with configuration, then append it to the config file.
+:: Later config values overwrite earlier values, so appending is the right thing to do
+if defined EMQX_CONF (
+    if "!EMQX_CONF!" == "{configuration:/emqx/emqx.conf}" (
+        echo No additional configuration specified
+    ) else (
+        echo We have user-provided config
+        echo !EMQX_CONF! >> emqx.conf
+    )
+) else (
+    echo No EMQX_CONF provided
+)

--- a/recipe.json
+++ b/recipe.json
@@ -34,7 +34,8 @@
         "listener.ssl.external.max_connections": "1024000",
         "listener.ssl.external.rate_limit": "",
         "listener.ssl.external.handshake_timeout": "15s",
-        "listener.ssl.external.max_conn_rate": "500"
+        "listener.ssl.external.max_conn_rate": "500",
+        "emqx.conf": ""
       }
     }
   },
@@ -54,10 +55,11 @@
           "script": "copy /y /d {artifacts:decompressedPath}\\emqx\\emqx\\data\\loaded_plugins {work:path}\\data\\loaded_plugins"
         },
         "startup": {
-          "script": "{artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd console",
+          "script": "{artifacts:decompressedPath}\\emqx\\emqx\\bin\\copy_config.cmd && {artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd console",
           "timeout": "{configuration:/startupTimeoutSeconds}"
         },
         "setEnv": {
+          "EMQX_CONF": "{configuration:/emqx/emqx.conf}",
           "EMQX_LOG__TO": "{configuration:/emqx/log.to}",
           "EMQX_LOG__DIR": "{work:path}\\logs",
           "EMQX_LOG__LEVEL": "{configuration:/emqx/log.level}",
@@ -106,6 +108,7 @@
           "Timeout": "{configuration:/startupTimeoutSeconds}"
         },
         "setEnv": {
+          "EMQX_CONF": "{configuration:/emqx/emqx.conf}",
           "EMQX_LOG__TO": "{configuration:/emqx/log.to}",
           "EMQX_LOG__DIR": "{work:path}\\logs",
           "EMQX_LOG__LEVEL": "{configuration:/emqx/log.level}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds `copy_config.cmd` file for Windows which checks for a user-provided configuration (from environment variable from GG component config), and then applies it to EMQX by copying our default config, then adding the customer's config to it. This change is for Windows only, Linux will be implemented in a similar way after this.

NOTE: The total set of all environment variables for a process on Windows is limited to 32KB. This means that customer configuration will be limited to something less than 32KB, depending on their system's default environment variables (and the few extra variables that we are setting).

### Testing
Validated that:

1. User provided configuration is merged in when provided
2. When not provided, or when upgrading from existing versions which don't have this, nothing is added beyond our default config file.
3. User config takes precedence over our default config
4. Users can specify config separated by `\n` or `\r\n`

Example config for testing:

```json
{
  "emqx": {
    "emqx.conf": "acl_file = /acl1.conf\nacl_file = /acl2.conf"
  }
}
```
^ In this case, the last value takes precedence, so the value for `acl_file` will be `/acl2.conf`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
