### PR TITLE
feat: feature flag server cert updates

### DIFF
--- a/src/aws_greengrass_emqx_auth_app.erl
+++ b/src/aws_greengrass_emqx_auth_app.erl
@@ -17,16 +17,15 @@
 ]).
 
 start(_StartType, _StartArgs) ->
-%%  Uncomment to load server certs in from the filesystem
   {ok, Sup} = aws_greengrass_emqx_auth_sup:start_link(),
   port_driver_integration:start(),
   case tls_custom_certificate_verification:enable() of
     ok -> ok;
     nossl ->
-      ErrorString = io_lib:format("Could not find active Ssl listener"),
+      ErrorString = "Could not find active SSL listener",
       throw({error, ErrorString});
     {error, Reason} ->
-      ErrorString = io_lib:format("Failed to enable ssl custom certificate verification. Error: ~s",
+      ErrorString = io_lib:format("Failed to enable SSL custom certificate verification. Error: ~s",
         [Reason]),
       throw({error, ErrorString})
   end,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Utilize the `greengrass_broker_server_certificate_mode` flag to control whether or not the plugin handles server certificate updates.

*Testing:*

1) With a fresh work directory, ran the component with `greengrass_broker_server_certificate_mode=enabled` and verified that cert files were written to the work directory on startup.
2) With a fresh work directory, ran the component with `greengrass_broker_server_certificate_mode=disabled` and verified that NO cert files were written to the work directory on startup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
