### PR TITLE
fix: copy loaded_plugins to work root

### DIFF
--- a/recipe.json
+++ b/recipe.json
@@ -52,7 +52,7 @@
       },
       "Lifecycle": {
         "install": {
-          "script": "copy /y /d {artifacts:decompressedPath}\\emqx\\emqx\\data\\loaded_plugins {work:path}\\data\\loaded_plugins"
+          "script": "copy /y /d {artifacts:decompressedPath}\\emqx\\emqx\\data\\loaded_plugins {work:path}\\loaded_plugins"
         },
         "startup": {
           "script": "{artifacts:decompressedPath}\\emqx\\emqx\\bin\\copy_config.cmd && {artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd console",
@@ -65,7 +65,7 @@
           "EMQX_LOG__LEVEL": "{configuration:/emqx/log.level}",
           "EMQX_NODE__DATA_DIR": "{work:path}\\data",
           "EMQX_PLUGINS__EXPAND_PLUGINS_DIR": "{work:path}\\plugin-data",
-          "EMQX_PLUGINS__LOADED_FILE": "{work:path}\\data\\loaded_plugins",
+          "EMQX_PLUGINS__LOADED_FILE": "{work:path}\\loaded_plugins",
           "RESTART_IDENTIFIER": "{configuration:/restartIdentifier}",
           "EMQX_LISTENER__SSL__EXTERNAL__KEYFILE": "{work:path}\\data\\key.pem",
           "EMQX_LISTENER__SSL__EXTERNAL__CERTFILE": "{work:path}\\data\\cert.pem",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During manual testing, found that our component won't start up with a clean work directory, due to `copy`-ing of `loaded_plugins` to a nested folder.  

Fix is to simply copy `loaded_plugins` to root of work directory.

*Testing:*
1) clear emqx work dir
2) run the component and verify emqx fully starts up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
