### PR TITLE
fix: wait for port driver process to register

### DIFF
--- a/src/port_driver_integration.erl
+++ b/src/port_driver_integration.erl
@@ -51,7 +51,7 @@ start() ->
   receive
     %% ensure process is registered so we can
     %% safely send messages without race conditions
-    port_driver_initialized -> logger:debug("Initialized port_driver")
+    port_driver_initialized -> ok
   end.
 
 stop() ->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change is required in advance of implementing `greengrass_authorization_mode` feature flag.

Currently, `port_driver_integration:start` will exit before its internal process, `process`, is registered (happens async).  There is a dormant race condition between this and `port_driver_integeration:register_fun` and similar functions that send messages to `process`.

This race currently is always won because we restart the emqx ssl listener before we attempt to call into our port driver integration.  However, as we look to utilize the new `greengrass_authorization_mode` feature flag, this restart will not occur in some cases, exposing the race condition.

https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/blob/f7a4021f68d88ccfd77e08fb00988a34ae00e6e4/src/aws_greengrass_emqx_auth_app.erl#L21-L32

Line 21: initialization happens async, may not finish in time.
Line 22: triggers listener restart. this will be gated by a feature flag soon.
Line 32: usage of port driver, initialization must be complete

*Testing:*

* Regression: ran manually, confirmed emqx and our plugin starts up w/o failures. 
* Tested with `flag/auth` branch, with`greengrass_authorization_mode=bypass`, which exposes the race condition, confirmed that emqx and our plugin starts up without failures.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
