### PR TITLE
refactor(logging): move common log level parsing to a header

### DIFF
--- a/port_driver/CMakeLists.txt
+++ b/port_driver/CMakeLists.txt
@@ -51,7 +51,7 @@ include_directories(SYSTEM ${ERL_INCLUDES})
 
 set(PORT_DRIVER_TARGET_NAME "${PROJECT_NAME}")
 link_directories("${ERL_LIBS}")
-add_library(${PORT_DRIVER_TARGET_NAME} SHARED port_driver.cpp)
+add_library(${PORT_DRIVER_TARGET_NAME} SHARED port_driver.cpp common.cpp)
 set_target_properties(${PORT_DRIVER_TARGET_NAME} PROPERTIES PREFIX "")
 set_property(TARGET ${PORT_DRIVER_TARGET_NAME} PROPERTY CXX_STANDARD 23)
 

--- a/port_driver/common.cpp
+++ b/port_driver/common.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+aws_log_level crtStringToLogLevel(const std::string &level) {
+    // Crt defined log levels
+    if (level == "none") {
+        return AWS_LL_NONE;
+    }
+    if (level == "trace") {
+        return AWS_LL_TRACE;
+    }
+    if (level == "debug") {
+        return AWS_LL_DEBUG;
+    }
+    if (level == "info") {
+        return AWS_LL_INFO;
+    }
+    if (level == "warn") {
+        return AWS_LL_WARN;
+    }
+    if (level == "error") {
+        return AWS_LL_ERROR;
+    }
+    if (level == "fatal") {
+        return AWS_LL_FATAL;
+    }
+    // Default to warn
+    return AWS_LL_WARN;
+}
+
+aws_log_level erlangStringToLogLevel(const std::string &level) {
+    // Erlang log levels
+    // debug, info, notice, warning, error, critical, alert, emergency
+    if (level == "debug") {
+        return AWS_LL_TRACE;
+    }
+    if (level == "info") {
+        return AWS_LL_DEBUG;
+    }
+    if (level == "notice") {
+        return AWS_LL_INFO;
+    }
+    if (level == "warning") {
+        return AWS_LL_WARN;
+    }
+    if (level == "error") {
+        return AWS_LL_ERROR;
+    }
+    if (level == "emergency") {
+        return AWS_LL_FATAL;
+    }
+    // Default to warn
+    return AWS_LL_WARN;
+}

--- a/port_driver/common.h
+++ b/port_driver/common.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <logger.h>
+
+aws_log_level crtStringToLogLevel(const std::string &level);
+aws_log_level erlangStringToLogLevel(const std::string &level);

--- a/port_driver/port_driver.cpp
+++ b/port_driver/port_driver.cpp
@@ -4,12 +4,12 @@
  */
 
 #include "port_driver.h"
+#include "common.h"
 #include "defer.h"
 #include <aws/crt/Api.h>
 #include <cda_integration.h>
 #include <cstring>
 #include <filesystem>
-#include <logger.h>
 #include <memory>
 #include <string>
 
@@ -17,8 +17,6 @@ using DriverContext = struct {
     ErlDrvPort port;
     ClientDeviceAuthIntegration *cda_integration;
 };
-
-static struct aws_logger our_logger {};
 
 struct atoms {
     ErlDrvTermData data;
@@ -41,57 +39,7 @@ static const char *EMQX_LOG_ENV_VAR = "EMQX_LOG__DIR";
 static const char *EMQX_DATA_ENV_VAR = "EMQX_NODE__DATA_DIR";
 static const char *CRT_LOG_LEVEL_ENV_VAR = "CRT_LOG_LEVEL";
 
-static aws_log_level crtStringToLogLevel(const std::string &level) {
-    // Crt defined log levels
-    if (level == "none") {
-        return AWS_LL_NONE;
-    }
-    if (level == "trace") {
-        return AWS_LL_TRACE;
-    }
-    if (level == "debug") {
-        return AWS_LL_DEBUG;
-    }
-    if (level == "info") {
-        return AWS_LL_INFO;
-    }
-    if (level == "warn") {
-        return AWS_LL_WARN;
-    }
-    if (level == "error") {
-        return AWS_LL_ERROR;
-    }
-    if (level == "fatal") {
-        return AWS_LL_FATAL;
-    }
-    // Default to warn
-    return AWS_LL_WARN;
-}
-
-static aws_log_level erlangStringToLogLevel(const std::string &level) {
-    // Erlang log levels
-    // debug, info, notice, warning, error, critical, alert, emergency
-    if (level == "debug") {
-        return AWS_LL_TRACE;
-    }
-    if (level == "info") {
-        return AWS_LL_DEBUG;
-    }
-    if (level == "notice") {
-        return AWS_LL_INFO;
-    }
-    if (level == "warning") {
-        return AWS_LL_WARN;
-    }
-    if (level == "error") {
-        return AWS_LL_ERROR;
-    }
-    if (level == "emergency") {
-        return AWS_LL_FATAL;
-    }
-    // Default to warn
-    return AWS_LL_WARN;
-}
+static struct aws_logger our_logger {};
 
 EXPORTED ErlDrvData drv_start(ErlDrvPort port, [[maybe_unused]] char *buff) { // NOLINT(readability-non-const-parameter)
     const char *logLocation = std::getenv(EMQX_LOG_TO_ENV_VAR);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Moves log level parsing out of port driver so it can be used by another feature in a future PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
