### PR TITLE
fix: point acl file to work dir

### DIFF
--- a/recipe.json
+++ b/recipe.json
@@ -63,6 +63,7 @@
           "ORIG_EMQX_NODE__ETC_DIR": "{artifacts:decompressedPath}\\emqx\\emqx\\etc",
           "EMQX_NODE__DATA_DIR": "{work:path}\\data",
           "EMQX_NODE__ETC_DIR": "{work:path}\\etc",
+          "EMQX_ACL_FILE": "{work:path}\\etc\\acl.conf",
           "EMQX_PLUGINS__LOADED_FILE": "{work:path}\\data\\loaded_plugins",
           "EMQX_MODULES__LOADED_FILE": "{work:path}\\data\\loaded_modules",
           "EMQX_PLUGINS__EXPAND_PLUGINS_DIR": "{work:path}\\plugin-data",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During manual testing, found that `acl_file` config still refers to acl file in greengrass `packages`, rather than the one in work directory, which means that overrides to the acl file aren't picked up.

The fix is to simply point acl file config to work dir.

*Testing*
Confirmed through manual testing of https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/96, which relied on `acl.conf` as a fallback.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
