### PR TITLE
feat: use greengrass work dir as erl working dir

### DIFF
--- a/bin/package.py
+++ b/bin/package.py
@@ -42,26 +42,21 @@ def patch(original, patch_file):
     return out.getvalue().decode()
 
 
-def do_patch(zip_path, erts_version="11.0", add=None):
-    # ini file is only for windows, but we'll just throw it in no matter what. Use \r\n for windows line endings
-    with open("build/erl.ini", "w") as erl_ini:
-        erl_ini.writelines(["[erlang]\r\n",
-                            f"Bindir=.\\\\erts-{erts_version}\\\\bin\r\n",
-                            "Progname=erl\r\n",
-                            "Rootdir=.\\\\\r\n"
-                            ])
-    
+def do_patch(zip_path, add=None):
     if add is None:
         add = {}
-    add[f"emqx/erts-{erts_version}/bin/erl.ini"] = "build/erl.ini"
     add["emqx/data/loaded_plugins"] = "patches/loaded_plugins"
     add["emqx/THIRD-PARTY-LICENSES"] = "THIRD-PARTY-LICENSES"
 
-    update_zip(zipname=zip_path, updates={
-        "emqx/bin/emqx.cmd": lambda o: patch(o, "patches/emqx.cmd.diff"),
-        "emqx/bin/emqx": lambda o: patch(o, "patches/emqx.diff"),
-        "emqx/bin/emqx_ctl.cmd": lambda o: patch(o, "patches/emqx_ctl.diff")
-    }, add=add)
+    update_zip(
+        zipname=zip_path,
+        updates={
+            "emqx/bin/emqx.cmd": lambda o: patch(o, "patches/emqx.cmd.diff"),
+            "emqx/bin/emqx": lambda o: patch(o, "patches/emqx.diff"),
+            "emqx/bin/emqx_ctl.cmd": lambda o: patch(o, "patches/emqx_ctl.diff")
+        },
+        add=add
+    )
 
 
 if __name__ == "__main__":

--- a/patches/emqx.cmd.diff
+++ b/patches/emqx.cmd.diff
@@ -1,15 +1,9 @@
---- emqx.cmd	2022-08-31 07:20:47.000000000 -0400
-+++ emqx.cmd	2022-09-01 13:52:36.000000000 -0400
-@@ -35,12 +35,23 @@
- @for %%A in ("%script_dir%\..") do @(
-   set rel_root_dir=%%~fA
- )
-+@if exist %rel_root_dir% (
-+  cd /d %rel_root_dir%
-+)
+--- emqx.cmd	(revision 2af895e5796695f9d0e1538b73401d11531909d4)
++++ emqx.cmd	(date 1662698710131)
+@@ -38,9 +38,17 @@
  @set rel_dir=%rel_root_dir%\releases\%rel_vsn%
  @set RUNNER_ROOT_DIR=%rel_root_dir%
- 
+
 -@set etc_dir=%rel_root_dir%\etc
 +@if defined EMQX_NODE__ETC_DIR (
 +  set etc_dir=%EMQX_NODE__ETC_DIR%
@@ -24,27 +18,27 @@
 +  @set data_dir=%rel_root_dir%\data
 +)
  @set emqx_conf=%etc_dir%\emqx.conf
- 
+
  @call :find_erts_dir
-@@ -72,7 +83,7 @@
+@@ -72,7 +80,7 @@
  )
- 
+
  :: Write the erl.ini file to set up paths relative to this script
 -@call :write_ini
 +:: @call :write_ini
- 
+
  :: If a start.boot file is not present, copy one from the named .boot file
  @if not exist "%rel_dir%\start.boot" (
-@@ -149,7 +160,7 @@
+@@ -149,7 +157,7 @@
  @goto :eof
- 
+
  :generate_app_config
 -@set gen_config_cmd=%escript% %cuttlefish% -i %rel_dir%\emqx.schema -c %etc_dir%\emqx.conf -d %data_dir%\configs generate
 +@set gen_config_cmd=%escript% %cuttlefish% -i %rel_dir%\emqx.schema -c %emqx_conf% -d %data_dir%\configs generate
  @for /f "delims=" %%A in ('%%gen_config_cmd%%') do @(
    set generated_config_args=%%A
  )
-@@ -224,6 +235,15 @@
+@@ -224,6 +232,15 @@
  :: window service?
  :: @%erlsrv% stop %service_name%
  @%escript% %nodetool% %node_type% %node_name% -setcookie %node_cookie% stop
@@ -58,9 +52,9 @@
 +)
 +@%epmd% -kill
  @goto :eof
- 
+
  :: Relup and reldown
-@@ -243,11 +263,9 @@
+@@ -243,11 +260,9 @@
  @call :create_mnesia_dir
  @call :generate_app_config
  @set args=%sys_config% %generated_config_args% -mnesia dir '%mnesia_dir%'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Based on a suggestion from @MikeDombo in https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/102, this PR changes the working directory of emqx/erlang to greengrass work directory. 

This eliminates the need for https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/102 and covers the case for all config properties that reference the `etc` dir.

Testing:
This has been manually tested using `flag/auth` branch, where `acl.conf` has been modified via greengrass config.  This proves that emqx reads from `acl.conf` in the work dir rather than packages.  Previously, this was not the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
