### PR TITLE
fix: remove default certs from etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ COPY --from=builder /build/patches/entrypoint.sh /usr/bin/
 COPY --from=builder /build/emqx/deploy/docker/docker-entrypoint.sh /usr/bin/
 COPY --from=builder /build/build/emqx/ /opt/emqx
 
+# Remove the default certs that ship with EMQX just to be sure they can't be used for any reason
+RUN rm -rf /opt/emqx/etc/certs
 # Backup the etc files so that we always have the defaults available to us
 RUN cp -r /opt/emqx/etc /opt/emqx/etcOrig
 RUN cp -r /opt/emqx/data /opt/emqx/dataOrig

--- a/bin/build.py
+++ b/bin/build.py
@@ -198,6 +198,8 @@ def main():
             os.remove(f'_build/emqx/rel/emqx/erts-{erts_version}/bin/erl.ini')
         except FileNotFoundError:
             pass
+        # Remove the default certs that ship with EMQX just to be sure they can't be used for any reason
+        shutil.rmtree("_build/emqx/rel/emqx/etc/certs")
 
         os.chdir(current_abs_path)
         pathlib.Path("build").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change deletes the `certs` directory from under `etc` which ship with EMQX by default. Making this change to ensure that there is no chance that these certs could be used for any reason, even accidentally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
