### PR TITLE
refactor: move listener functions to new file

### DIFF
--- a/src/aws_greengrass_emqx_listeners.erl
+++ b/src/aws_greengrass_emqx_listeners.erl
@@ -1,0 +1,83 @@
+%%--------------------------------------------------------------------
+%%  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+%%  SPDX-License-Identifier: Apache-2.0
+%%--------------------------------------------------------------------
+
+-module(aws_greengrass_emqx_listeners).
+
+-export([update_ssl_listener_options/1, start_updated_ssl_listener/1]).
+
+
+-spec(update_ssl_listener_options(function()) -> emqx_listeners:listener() | nossl).
+update_ssl_listener_options(CustomVerifyFun) ->
+  case find_ssl_listener(emqx:get_env(listeners, [])) of
+    nossl -> nossl;
+    SslListener ->
+      NewListenerOpts = add_custom_verify_to_ssl_options(maps:get('opts', SslListener, []), CustomVerifyFun),
+      maps:put('opts', NewListenerOpts, SslListener)
+  end.
+
+-spec(add_custom_verify_to_ssl_options(Options :: list(), CustomVerifyFun :: function()) -> list()).
+add_custom_verify_to_ssl_options(Options, CustomVerifyFun) ->
+  case proplists:get_value(ssl_options, Options) of
+    undefined -> Options;
+    SslOpts ->
+      NewSslOpts = lists:append(SslOpts,
+        [{verify_fun,
+          {
+            CustomVerifyFun, []
+          }
+        }]),
+      replace(Options, ssl_options, NewSslOpts)
+  end.
+
+-spec(start_updated_ssl_listener(emqx_listeners:listener()) -> ok | {error, any()}).
+start_updated_ssl_listener(UpdatedSslListener) ->
+  case restart_ssl_listener(UpdatedSslListener) of
+    ok ->
+      logger:info("Restarted ~p ~w listener on port ~w with custom certificate verification",
+        [maps:get(name, UpdatedSslListener),
+          maps:get(proto, UpdatedSslListener),
+          maps:get(listen_on, UpdatedSslListener)]),
+      update_ssl_listener_env(UpdatedSslListener),
+      ok;
+    {error, Reason} ->
+      logger:error("Failed to restart ~p ~w listener on port ~w with custom certificate verification: ~p",
+        [maps:get(name, UpdatedSslListener),
+          maps:get(proto, UpdatedSslListener),
+          maps:get(listen_on, UpdatedSslListener),
+          Reason]),
+      {error, Reason}
+  end.
+
+-spec(restart_ssl_listener(emqx_listeners:listener()) -> ok | {error, any()}).
+restart_ssl_listener(UpdatedSslListener) ->
+  case stop_existing_ssl_listener() of
+    ok -> start_listener(UpdatedSslListener);
+    {error, Reason} -> {error, Reason}
+  end.
+
+-spec(stop_existing_ssl_listener() -> ok | {error, any()}).
+stop_existing_ssl_listener() ->
+  case find_ssl_listener(emqx:get_env(listeners, [])) of
+    nossl -> ok;
+    SslListener -> emqx_listeners:stop_listener(SslListener)
+  end.
+
+-spec(start_listener(emqx_listeners:listener()) -> ok | {error, any()}).
+start_listener(UpdatedSslListener) ->
+  case emqx_listeners:start_listener(UpdatedSslListener) of
+    ok -> ok;
+    Error -> {error, Error}
+  end.
+
+-spec(find_ssl_listener(Listeners :: list()) -> emqx_listeners:listener() | nossl).
+find_ssl_listener([]) -> nossl;
+find_ssl_listener([#{name := "external", proto := 'ssl'} = L | _]) -> L;
+find_ssl_listener([_ | Rest]) -> find_ssl_listener(Rest).
+
+-spec(update_ssl_listener_env(emqx_listeners:listener()) -> ok).
+update_ssl_listener_env(SslListener) ->
+  emqx_listeners:update_listeners_env('update', SslListener).
+
+replace(Opts, Key, Value) -> [{Key, Value} | proplists:delete(Key, Opts)].

--- a/src/tls_custom_certificate_verification.erl
+++ b/src/tls_custom_certificate_verification.erl
@@ -9,6 +9,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -import(port_driver_integration, [verify_client_certificate/1]).
+-import(aws_greengrass_emqx_listeners, [update_ssl_listener_options/1, start_updated_ssl_listener/1]).
 
 -export([enable/0]).
 
@@ -16,32 +17,9 @@
 %% by restarting ssl listener with custom certificate verification
 -spec(enable() -> ok | {error, any()} | nossl).
 enable() ->
-  case update_ssl_listener_options() of
+  case update_ssl_listener_options(fun custom_verify/3) of
     nossl -> nossl;
     UpdatedSslListener -> start_updated_ssl_listener(UpdatedSslListener)
-  end.
-
--spec(update_ssl_listener_options() -> emqx_listeners:listener() | nossl).
-update_ssl_listener_options() ->
-  case find_ssl_listener(emqx:get_env(listeners, [])) of
-    nossl -> nossl;
-    SslListener ->
-      NewListenerOpts = add_custom_verify_to_ssl_options(maps:get('opts', SslListener, [])),
-      maps:put('opts', NewListenerOpts, SslListener)
-  end.
-
--spec(add_custom_verify_to_ssl_options(Options :: list()) -> list()).
-add_custom_verify_to_ssl_options(Options) ->
-  case proplists:get_value(ssl_options, Options) of
-    undefined -> Options;
-    SslOpts ->
-      NewSslOpts = lists:append(SslOpts,
-        [{verify_fun,
-          {
-            fun custom_verify/3, []
-          }
-        }]),
-      replace(Options, ssl_options, NewSslOpts)
   end.
 
 -spec(custom_verify(OtpCert :: #'OTPCertificate'{}, Event :: {bad_cert, Reason :: atom() |
@@ -88,54 +66,3 @@ verify_client_certificate(OtpCert, UserState) ->
 otpcert_to_pem(OtpCert) ->
   Cert = public_key:pkix_encode('OTPCertificate', OtpCert, otp),
   base64:encode_to_string(Cert).
-
--spec(start_updated_ssl_listener(emqx_listeners:listener()) -> ok | {error, any()}).
-start_updated_ssl_listener(UpdatedSslListener) ->
-  case restart_ssl_listener(UpdatedSslListener) of
-    ok ->
-      logger:info("Restarted ~p ~w listener on port ~w with custom certificate verification",
-        [maps:get(name, UpdatedSslListener),
-          maps:get(proto, UpdatedSslListener),
-          maps:get(listen_on, UpdatedSslListener)]),
-      update_ssl_listener_env(UpdatedSslListener),
-      ok;
-    {error, Reason} ->
-      logger:error("Failed to restart ~p ~w listener on port ~w with custom certificate verification: ~p",
-        [maps:get(name, UpdatedSslListener),
-          maps:get(proto, UpdatedSslListener),
-          maps:get(listen_on, UpdatedSslListener),
-          Reason]),
-      {error, Reason}
-  end.
-
--spec(restart_ssl_listener(emqx_listeners:listener()) -> ok | {error, any()}).
-restart_ssl_listener(UpdatedSslListener) ->
-  case stop_existing_ssl_listener() of
-    ok -> start_listener(UpdatedSslListener);
-    {error, Reason} -> {error, Reason}
-  end.
-
--spec(stop_existing_ssl_listener() -> ok | {error, any()}).
-stop_existing_ssl_listener() ->
-  case find_ssl_listener(emqx:get_env(listeners, [])) of
-    nossl -> ok;
-    SslListener -> emqx_listeners:stop_listener(SslListener)
-  end.
-
--spec(start_listener(emqx_listeners:listener()) -> ok | {error, any()}).
-start_listener(UpdatedSslListener) ->
-  case emqx_listeners:start_listener(UpdatedSslListener) of
-    ok -> ok;
-    Error -> {error, Error}
-  end.
-
--spec(find_ssl_listener(Listeners :: list()) -> emqx_listeners:listener() | nossl).
-find_ssl_listener([]) -> nossl;
-find_ssl_listener([#{name := "external", proto := 'ssl'} = L | _]) -> L;
-find_ssl_listener([_ | Rest]) -> find_ssl_listener(Rest).
-
--spec(update_ssl_listener_env(emqx_listeners:listener()) -> ok).
-update_ssl_listener_env(SslListener) ->
-  emqx_listeners:update_listeners_env('update', SslListener).
-
-replace(Opts, Key, Value) -> [{Key, Value} | proplists:delete(Key, Opts)].


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Mostly cosmetic change, move all listener-specific functions to a new `aws_greengrass_emqx_listeners.erl`. This improves the clarity of `tls_custom_certificate_verification.erl` since it'll just house the verify function.

Only modification I had to make is to pass-through the verify function as a function argument

Testing:
Manual regression, confirmed that ggad message sending works



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
