### PR TITLE
chore: fixes for latest clang-tidy 15

### DIFF
--- a/port_driver/.clang-tidy
+++ b/port_driver/.clang-tidy
@@ -6,7 +6,7 @@ Checks: >-
   -modernize-use-trailing-return-type,-cppcoreguidelines-avoid-c-arrays,-modernize-avoid-c-arrays,
   -cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-avoid-non-const-global-variables,-concurrency-mt-unsafe
+  -cppcoreguidelines-avoid-non-const-global-variables,-concurrency-mt-unsafe,-modernize-macro-to-enum
 WarningsAsErrors: '*'
 CheckOptions:
   - key: readability-function-cognitive-complexity.IgnoreMacros

--- a/port_driver/cda_integration/lib/cda_integration.cpp
+++ b/port_driver/cda_integration/lib/cda_integration.cpp
@@ -38,7 +38,7 @@ GreengrassIPCWrapper &ClientDeviceAuthIntegration::getIPCWrapper() { return gree
 CertSubscribeUpdateStatus ClientDeviceAuthIntegration::subscribeToCertUpdates(
     std::unique_ptr<std::filesystem::path> basePath,
     std::unique_ptr<std::function<void(GG::CertificateUpdateEvent *)>> subscription) {
-    CertSubscribeUpdateStatus certSubscribeStatus =
+    const CertSubscribeUpdateStatus certSubscribeStatus =
         certificateUpdater.subscribeToUpdates(std::move(basePath), std::move(subscription));
     if (certSubscribeStatus != CertSubscribeUpdateStatus::SUBSCRIBE_SUCCESS) {
         LOG_E(CDA_INTEG_SUBJECT, "Failed to subscribe to cert updates with status %d", (int)certSubscribeStatus);
@@ -51,8 +51,8 @@ CertSubscribeUpdateStatus ClientDeviceAuthIntegration::subscribeToCertUpdates(
 std::unique_ptr<std::string> ClientDeviceAuthIntegration::get_client_device_auth_token(const char *clientId,
                                                                                        const char *pem) {
     LOG_D(CDA_INTEG_SUBJECT, "get_client_device_auth_token called with clientId: %s", clientId);
-    Aws::Crt::String clientIdStr(clientId);
-    Aws::Crt::String pemStr(pem);
+    const Aws::Crt::String clientIdStr(clientId);
+    const Aws::Crt::String pemStr(pem);
 
     GG::MQTTCredential mqttCredential;
     mqttCredential.SetClientId(clientIdStr);
@@ -104,9 +104,9 @@ AuthorizationStatus ClientDeviceAuthIntegration::on_check_acl(const char *client
     LOG_D(CDA_INTEG_SUBJECT, "on_check_acl called with clientId: %s, token: %s, resource: %s, operation: %s", clientId,
           token, resource, operation);
 
-    Aws::Crt::String tokenStr(token);
-    Aws::Crt::String resourceStr(resource);
-    Aws::Crt::String operationStr(operation);
+    const Aws::Crt::String tokenStr(token);
+    const Aws::Crt::String resourceStr(resource);
+    const Aws::Crt::String operationStr(operation);
 
     GG::AuthorizeClientDeviceActionRequest request;
     request.SetClientDeviceAuthToken(tokenStr);
@@ -154,7 +154,7 @@ AuthorizationStatus ClientDeviceAuthIntegration::on_check_acl(const char *client
 
 bool ClientDeviceAuthIntegration::verify_client_certificate(const char *certPem) {
     LOG_D(CDA_INTEG_SUBJECT, "verify_client_certificate called");
-    Aws::Crt::String certPemStr(certPem);
+    const Aws::Crt::String certPemStr(certPem);
 
     GG::ClientDeviceCredential clientDeviceCredential;
     clientDeviceCredential.SetClientDeviceCertificate(certPemStr);

--- a/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
+++ b/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
@@ -81,7 +81,7 @@ void CertificateUpdatesHandler::OnStreamEvent(GG::CertificateUpdateEvent *respon
         return;
     }
 
-    CertWriteStatus writeStatus = writeCertsToFiles(privateKey.value(), cert.value());
+    const CertWriteStatus writeStatus = writeCertsToFiles(privateKey.value(), cert.value());
     if (writeStatus != CertWriteStatus::WRITE_SUCCESS) {
         LOG_E(CERT_UPDATER_SUBJECT, "Failed to write certificates to files with code %d", (int)writeStatus);
         return;

--- a/port_driver/port_driver.cpp
+++ b/port_driver/port_driver.cpp
@@ -354,7 +354,7 @@ static void check_acl(void *buf) {
           "action %s",
           pack->client_id.get(), pack->auth_token.get(), pack->resource.get(), pack->operation.get());
 
-    AuthorizationStatus authorized = pack->context->cda_integration->on_check_acl(
+    const AuthorizationStatus authorized = pack->context->cda_integration->on_check_acl(
         pack->client_id.get(), pack->auth_token.get(), pack->resource.get(), pack->operation.get());
     switch (authorized) {
     case AuthorizationStatus::AUTHORIZED:
@@ -420,7 +420,7 @@ static void verify_client_certificate(void *buf) {
 
     LOG_D(PORT_DRIVER_SUBJECT, "Handling verify_client_certificate request");
 
-    bool result = pack->context->cda_integration->verify_client_certificate(pack->pem.get());
+    const bool result = pack->context->cda_integration->verify_client_certificate(pack->pem.get());
 
     pack->result = result ? ATOMS.valid : ATOMS.invalid;
     pack->returnCode = RETURN_CODE_SUCCESS;
@@ -465,7 +465,7 @@ void handle_certificate_update_subscription(DriverContext *context) {
         [context]([[maybe_unused]] Aws::Greengrass::CertificateUpdateEvent *event) {
             send_event_to_port(context, ATOMS.certificate_update);
         });
-    CertSubscribeUpdateStatus result =
+    const CertSubscribeUpdateStatus result =
         context->cda_integration->subscribeToCertUpdates(std::move(baseDirPath), std::move(callback));
     result_atom = result == CertSubscribeUpdateStatus::SUBSCRIBE_SUCCESS ? ATOMS.valid : ATOMS.invalid;
     return_code = RETURN_CODE_SUCCESS;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Just adding `const` in some places to resolve warnings from the new version of clang-tidy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
