### PR TITLE
refactor: rename auth plugin options

### DIFF
--- a/priv/aws_greengrass_emqx_auth.schema
+++ b/priv/aws_greengrass_emqx_auth.schema
@@ -3,12 +3,12 @@
 %%  SPDX-License-Identifier: Apache-2.0
 %%--------------------------------------------------------------------
 
-{mapping, "greengrass_authorization_mode", "aws_greengrass_emqx_auth.greengrass_authorization_mode", [
+{mapping, "auth_mode", "aws_greengrass_emqx_auth.auth_mode", [
   {default, enabled},
-  {datatype, {enum, [enabled, enabled_bypass_on_failure, bypass]}}
+  {datatype, {enum, [enabled, bypass_on_failure, bypass]}}
 ]}.
 
-{mapping, "greengrass_broker_server_certificate_mode", "aws_greengrass_emqx_auth.greengrass_broker_server_certificate_mode", [
-  {default, enabled},
-  {datatype, {enum, [enabled, disabled]}}
+{mapping, "use_greengrass_managed_certificates", "aws_greengrass_emqx_auth.use_greengrass_managed_certificates", [
+  {default, true},
+  {datatype, {enum, [true, false]}}
 ]}.

--- a/src/aws_greengrass_emqx_auth.erl
+++ b/src/aws_greengrass_emqx_auth.erl
@@ -27,10 +27,10 @@ load(Env) ->
 %%--------------------------------------------------------------------
 
 execute_auth_hook(Hook) ->
-  case aws_greengrass_emqx_conf:greengrass_authorization_mode() of
+  case aws_greengrass_emqx_conf:auth_mode() of
     enabled ->
       Hook();
-    enabled_bypass_on_failure ->
+    bypass_on_failure ->
       case catch Hook() of
         {_, #{auth_result := success}} = AuthNHookSuccess -> AuthNHookSuccess;
         {_, allow} = AuthZHookSuccess -> AuthZHookSuccess;
@@ -41,7 +41,7 @@ execute_auth_hook(Hook) ->
   end.
 
 on_client_connect(ConnInfo = #{clientid := ClientId, peercert := PeerCert, proto_ver := ClientVersion}, Props, _Env) ->
-  case aws_greengrass_emqx_conf:greengrass_authorization_mode() of
+  case aws_greengrass_emqx_conf:auth_mode() of
     bypass ->
       {ok, Props};
     _ ->

--- a/src/aws_greengrass_emqx_auth_app.erl
+++ b/src/aws_greengrass_emqx_auth_app.erl
@@ -20,7 +20,7 @@ start(_StartType, _StartArgs) ->
   {ok, Sup}.
 
 enable_cert_verification() ->
-  case aws_greengrass_emqx_conf:greengrass_authorization_mode() of
+  case aws_greengrass_emqx_conf:auth_mode() of
     bypass -> ok;
     _ ->
       case tls_custom_certificate_verification:enable() of

--- a/src/aws_greengrass_emqx_certs.erl
+++ b/src/aws_greengrass_emqx_certs.erl
@@ -8,15 +8,15 @@
 -export([load/0]).
 
 load() ->
-  case aws_greengrass_emqx_conf:greengrass_broker_server_certificate_mode() of
-    enabled ->
+  case aws_greengrass_emqx_conf:use_greengrass_managed_certificates() of
+    true ->
       port_driver_integration:register_fun(certificate_update, fun cleanPemCache/0),
       %% Subscribe to certificate updates. On update,
       %% the certificate and its private key are written
       %% to the EMQX component work directory. The EMQX
       %% ssl listener is configured to read these files.
       port_driver_integration:request_certificates();
-    disabled ->
+    false ->
       ok
   end.
 

--- a/src/aws_greengrass_emqx_conf.erl
+++ b/src/aws_greengrass_emqx_conf.erl
@@ -5,17 +5,17 @@
 
 -module(aws_greengrass_emqx_conf).
 
--export([greengrass_authorization_mode/0, greengrass_broker_server_certificate_mode/0]).
+-export([auth_mode/0, use_greengrass_managed_certificates/0]).
 
--type(greengrass_authorization_mode() :: enabled | enabled_bypass_on_failure | bypass).
--type(greengrass_broker_server_certificate_mode() :: enabled | disabled).
+-type(auth_mode() :: enabled | bypass_on_failure | bypass).
+-type(use_greengrass_managed_certificates() :: true | false).
 
--export_type([greengrass_authorization_mode/0, greengrass_broker_server_certificate_mode/0]).
+-export_type([auth_mode/0, use_greengrass_managed_certificates/0]).
 
--spec(greengrass_authorization_mode() -> greengrass_authorization_mode()).
-greengrass_authorization_mode() ->
-  application:get_env(aws_greengrass_emqx_auth, greengrass_authorization_mode, enabled).
+-spec(auth_mode() -> auth_mode()).
+auth_mode() ->
+  application:get_env(aws_greengrass_emqx_auth, auth_mode, enabled).
 
--spec(greengrass_broker_server_certificate_mode() -> greengrass_broker_server_certificate_mode()).
-greengrass_broker_server_certificate_mode() ->
-  application:get_env(aws_greengrass_emqx_auth, greengrass_broker_server_certificate_mode, enabled).
+-spec(use_greengrass_managed_certificates() -> use_greengrass_managed_certificates()).
+use_greengrass_managed_certificates() ->
+  application:get_env(aws_greengrass_emqx_auth, use_greengrass_managed_certificates, true).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rename: 
- `greengrass_authorization_mode` --> `auth_mode`
- `enabled_bypass_on_failure` --> `bypass_on_failure`
- `greengrass_broker_server_certificate_mode` --> `use_greengrass_managed_certificates`
  - `enabled` --> `true`
  - `disabled` --> `false`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
