### PR TITLE
refactor: move config key name to separate file

### DIFF
--- a/port_driver/cda_integration/include/private/configuration_subscriber.h
+++ b/port_driver/cda_integration/include/private/configuration_subscriber.h
@@ -31,8 +31,6 @@ class ConfigurationUpdatesHandler : public GG::SubscribeToConfigurationUpdateStr
 
 class ConfigurationSubscriber {
   public:
-    inline static const std::string localOverrideNamespace = "localOverride";
-
     ConfigurationSubscriber(GG::GreengrassCoreIpcClient &client) : ipcClient(client), updatesHandler({}){};
     ConfigurationSubscribeStatus subscribe_to_configuration_updates(std::unique_ptr<std::function<void()>> callback);
 

--- a/port_driver/cda_integration/lib/configuration_subscriber.cpp
+++ b/port_driver/cda_integration/lib/configuration_subscriber.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "private/configuration_subscriber.h"
+#include "config.h"
 #include "logger.h"
 #include <aws/greengrass/GreengrassCoreIpcClient.h>
 
@@ -36,7 +37,7 @@ ConfigurationSubscriber::subscribe_to_configuration_updates(std::unique_ptr<std:
     }
 
     GG::SubscribeToConfigurationUpdateRequest request;
-    request.SetKeyPath({Aws::Crt::String(localOverrideNamespace)});
+    request.SetKeyPath({Aws::Crt::String(aws::greengrass::emqx::localOverrideNamespace)});
 
     auto activate = operation->Activate(request, nullptr);
     activate.wait();

--- a/port_driver/common.h
+++ b/port_driver/common.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <config.h>
 #include <logger.h>
 
 aws_log_level crtStringToLogLevel(const std::string &level);

--- a/port_driver/include/config.h
+++ b/port_driver/include/config.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string>
+
+namespace aws::greengrass::emqx {
+static const std::string localOverrideNamespace = "localOverride";
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`"localOverride"` constant will need to be used by cda_integration, in addition to its existing location in ConfigurationSubscriber, so factoring it out into a common file. Can also be used in write_config

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
