### PR TITLE
fix: kick clients if we cannot get a new auth token for them

### DIFF
--- a/src/aws_greengrass_emqx_auth.erl
+++ b/src/aws_greengrass_emqx_auth.erl
@@ -143,7 +143,8 @@ check_authorization(ClientId, AuthToken, Resource, Action, IsRetry) ->
       case authenticate_client_device(ClientId, get(cert_pem)) of
         ok -> check_authorization(ClientId, get(cda_auth_token), Resource, Action, true);
         stop ->
-          logger:info("Could not get a new auth token"),
+          logger:info("Could not get a new auth token. Kicking client (~s) to have client reconnect with updated credentials", [ClientId]),
+          emqx_mgmt:kickout_client(ClientId),
           unauthorized
       end;
     {ok, bad_token} when IsRetry == true ->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If a client connects with valid credentials and their session later expires, we'll try to get a new session started. This may fail if the credentials have become invalid, such as cert expiration. We will need to kick the client in this case such that the client will reconnect with the updated cert.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
