### PR TITLE
fix: kick clients if we cannot get a new auth token for them

### DIFF
--- a/aws_greengrass_emqx_auth/src/aws_greengrass_emqx_auth.erl
+++ b/aws_greengrass_emqx_auth/src/aws_greengrass_emqx_auth.erl
@@ -215,7 +215,8 @@ is_authorized({ok, bad_token}, Retries, _, ClientId, Resource, Action) when Retr
   case reauthenticate(ClientId) of
     {ok, _} -> is_authorized(Retries + 1, ClientId, Resource, Action);
     _ ->
-      logger:debug("Could not get a new auth token"),
+      logger:info("Could not get a new auth token. Kicking client (~s) to have client reconnect with updated credentials", [ClientId]),
+      emqx_mgmt:kickout_client(ClientId),
       ?UNAUTHORIZED
   end;
 is_authorized({ok, bad_token}, Retries, _, ClientId, Resource, Action) when Retries > 0 ->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Pulling https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/133 fix into v5 branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
