### PR TITLE
fix: spawn subscription callbacks as a separate process

### DIFF
--- a/aws_greengrass_emqx_auth/src/port_driver_integration.erl
+++ b/aws_greengrass_emqx_auth/src/port_driver_integration.erl
@@ -99,7 +99,9 @@ loop(Port, Inflight, Counter, FunMap) ->
     % handle event type from C++ by finding a registered callback (if any)
     {Port, event, EventType} ->
       Fun = maps:get(EventType, FunMap, fun empty/0),
-      Fun(),
+      %% perform the callback asynchronously, otherwise this loop will deadlock
+      %% if the caller calls into port_driver_integration
+      spawn_link(Fun),
       loop(Port, Inflight, Counter, FunMap);
     {call, Caller, Msg, async} ->
       RequestId = counters:get(Counter, 1),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If a `port_driver_integration` callback calls into `port_driver_integration` a deadlock will occur, as the callback is waiting for it's code to finish, but the code needs the port driver loop to complete its task.  For example, if a configuration subscription callback calls get configuration.  To address this, callbacks are called in a separate process, allowing the port driver loop to continue.

*Testing*
Confirmed via manual test where a config subscribe callback calls get configuration and logs the result.  Previously the get configuration call never executed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
