### PR TITLE
feat: update emqx configuration on greengrass conf update

### DIFF
--- a/aws_greengrass_emqx_auth/src/aws_greengrass_emqx_auth_app.erl
+++ b/aws_greengrass_emqx_auth/src/aws_greengrass_emqx_auth_app.erl
@@ -15,16 +15,12 @@ start(_StartType, _StartArgs) ->
   {ok, Sup} = aws_greengrass_emqx_auth_sup:start_link(),
   load_config(),
   port_driver_integration:start(),
-  port_driver_integration:subscribe_to_configuration_updates(fun on_configuration_update/0),
-  logger:info("Get Configuration Test: ~p", [port_driver_integration:get_configuration()]),
+  port_driver_integration:subscribe_to_configuration_updates(fun aws_greengrass_emqx_conf:update_configuration_from_ipc/0),
+  aws_greengrass_emqx_conf:update_configuration_from_ipc(),
   enable_cert_verification(),
   aws_greengrass_emqx_certs:load(),
   aws_greengrass_emqx_auth:load(application:get_all_env()),
   {ok, Sup}.
-
-on_configuration_update() ->
-  %% TODO get configuration and set emqx config
-  logger:info("Configuration update received").
 
 load_config() ->
   case aws_greengrass_emqx_conf:load() of


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Now that we have IPC GetConfiguration and SubscribeToConfigurationUpdates implemented, this PR ties them together.  When we get a config update, call get configuration and update emqx override file.

*Testing*
Deployed custom component, then modified the component configuration. Verified that local-override.conf file changed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
