### PR TITLE
fix: no more random data in map response

### DIFF
--- a/port_driver/port_driver.cpp
+++ b/port_driver/port_driver.cpp
@@ -144,8 +144,8 @@ struct packer {
     std::unique_ptr<std::string> strResult = {};
     std::shared_ptr<Aws::Crt::JsonView> jsonViewResult = {};
     std::stack<ErlDrvTermData> spec;
-    std::vector<std::shared_ptr<double>> numbers;
-    std::vector<std::shared_ptr<std::string>> strings;
+    std::vector<std::shared_ptr<double *>> numbers;
+    std::vector<std::shared_ptr<std::string *>> strings;
     DriverContext *context;
     ErlDrvTermData result = ATOMS.fail;
     char returnCode = RETURN_CODE_UNEXPECTED;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issue where binary and double responses sometimes were returned as garbage.

*Testing*
Manual test by updating gg config multiple times, which triggers GetConfiguration call. After 5 updates, each returned a valid map with no random data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
