### PR TITLE
fix(docker): use proper plugin path when packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ WORKDIR /build
 
 COPY --from=build-base /build/bin bin
 COPY --from=emqx /build/emqx/ emqx
-COPY --from=plugin /build/aws_greengrass_emqx_auth/_build aws_greengrass_emqx_auth/_build
+COPY --from=plugin /build/emqx/_build/emqx/rel/emqx/plugins/aws_greengrass_emqx_auth-1.0.0/aws_greengrass_emqx_auth-1.0.0 emqx/_build/emqx/rel/emqx/plugins/aws_greengrass_emqx_auth-1.0.0/aws_greengrass_emqx_auth-1.0.0
 COPY THIRD-PARTY-LICENSES .
 COPY patches/emqx.cmd.diff patches/emqx.conf patches/emqx.diff patches/msvcr120.dll patches/acl.conf patches/
 COPY bin/package.py bin/build_emqx.py bin/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Points `package` docker layer to use the proper path when referring to output from `plugin` layer

*Testing:*
Confirmed by building the container, ssh-ing in, and verifying that `write_config` is in location defined in `patches/entrypoint.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
