### PR TITLE
chore: set logging to single line mode

### DIFF
--- a/patches/emqx.conf
+++ b/patches/emqx.conf
@@ -2487,7 +2487,7 @@ log {
     ## @path log.console_handler.single_line
     ## @type boolean()
     ## @default true
-    single_line  =  false
+    single_line  =  true
 
     ## @doc As long as the number of buffered log events is lower than this value,
     ## all log events are handled asynchronously. This means that the client process sending the log event,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Multline logs are unreadable in the greengrass logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
