### PR TITLE
fix: set authZ cache time to 1 minute

### DIFF
--- a/patches/emqx.conf
+++ b/patches/emqx.conf
@@ -1938,7 +1938,7 @@ authorization {
     ## @path authorization.cache.ttl
     ## @type emqx_schema:duration()
     ## @default 1m
-    ttl  =  5m
+    ttl  =  1m
   }
 
   ## @doc Authorization data sources.</br>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Auth cache time should be 1 minute to match emqx 4.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
