### PR TITLE
fix: revert removing .git from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ FROM build-base as sdk
 
 WORKDIR /build
 
-RUN git init
-COPY .gitmodules .
-COPY aws-iot-device-sdk-cpp-v2 aws-iot-device-sdk-cpp-v2
+COPY .gitmodules .gitmodules
+# TODO this breaks layer caching
+COPY .git .git
 
 COPY --from=build-base /build/bin bin
 COPY bin/build_sdk.py bin


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reverts Dockerfile change made in https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/157 to address error seen in codebuild:

```
CMake Error: The source directory "/build/aws-iot-device-sdk-cpp-v2" does not appear to contain CMakeLists.txt.
```

Eventually we can revisit the proper way to fix this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
