### PR TITLE
fix: cert loading race condition

### DIFF
--- a/gg/src/gg_app.erl
+++ b/gg/src/gg_app.erl
@@ -15,8 +15,7 @@ start(_StartType, _StartArgs) ->
   {ok, Sup} = gg_sup:start_link(),
   gg_port_driver:start(),
   gg_conf:start(),
-  %% TODO race condition, cert loading is async and we need them before restarting ssl listener
-  gg_certs:load(),
+  gg_certs:request_certificates(),
   enable_cert_verification(),
   gg:load(application:get_all_env()),
   {ok, Sup}.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a known race where we may restart the ssl listener before certificates have been written to the EMQX work directory. The solution is to simply block until we receive a cert update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
