### PR TITLE
chore: wait for initial config to be applied on startup

### DIFF
--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -67,11 +67,10 @@ request_update() ->
   ?UPDATE_PROC ! update.
 
 listen_for_update_requests(NotifyPID) ->
-  register(?UPDATE_PROC, self()),
-  gg_port_driver:subscribe_to_configuration_updates(fun request_update/0),
   ListenPID = spawn(?MODULE, do_listen_for_update_requests, [NotifyPID]),
   register(?UPDATE_PROC, ListenPID),
-  spawn(?MODULE, request_update, []).
+  gg_port_driver:subscribe_to_configuration_updates(fun request_update/0),
+  request_update().
 
 do_listen_for_update_requests(NotifyPID) ->
   receive


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ensure `gg_conf:start` blocks until initial GetConfiguration call is made and emqx/plugin configuration is fully applied. 

*Testing*
Confirmed through manual testing that setting plugin configuration works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
