### PR TITLE
chore(conf): support null/undefined

### DIFF
--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -113,7 +113,7 @@ update_conf(NewConf) ->
   update_conf(ExistingConf, NewConf).
 
 decode_conf(Conf) when is_binary(Conf) ->
-  case catch jiffy:decode(Conf, [return_maps, dedupe_keys, use_nil]) of
+  case catch jiffy:decode(Conf, [return_maps, dedupe_keys, {null_term, undefined}]) of
     DecodedConf when is_map(DecodedConf) -> DecodedConf;
     Err -> {error, Err}
   end.

--- a/patches/emqx.conf
+++ b/patches/emqx.conf
@@ -6,7 +6,7 @@ listeners {
 
     ssl.default {
         ssl_options {
-            cacertfile = ""
+            cacertfile = null
             verify = verify_peer
             versions = [tlsv1.3, tlsv1.2]
             fail_if_no_peer_cert = true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* When our plugin writes config, use `undefined` rather than `nil`
* Configure `cacertfile` as null, rather than `""`, which is invalid.

Note: `write_config` does not need to change, `null` has the same behavior as `undefined`.

Testing:
Tested that messages can still be sent by ggad on windows
* with default gg configuration
* with the following config:
```
{
  "reset": [
    ""
  ],
  "merge": {
    "emqx": {
      "log.level": "debug"
    },
    "localOverride": {
      "listeners": {
        "tcp": {
          "default": {
            "enabled": "false"
          }
        },
        "ws": {
          "default": {
            "enabled": "false"
          }
        },
        "wss": {
          "default": {
            "enabled": "false"
          }
        },
        "ssl": {
          "default": {
            "ssl_options": {
              "keyfile": "C:\\Users\\Administrator\\greengrass\\v2\\work\\aws.greengrass.clientdevices.mqtt.EMQX\\data\\key.pem",
              "certfile": "C:\\Users\\Administrator\\greengrass\\v2\\work\\aws.greengrass.clientdevices.mqtt.EMQX\\data\\cert.pem",
              "cacertfile": null,
              "verify": "verify_peer",
              "fail_if_no_peer_cert": "true"
            }
          }
        }
      }
    }
  }
}
```

:warning: as of EMQX 5.1.0, overriding configuration will also override environment variables, hence including keyfile and certfile in the above example. this will be address in subsequent PRs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
