### PR TITLE
feat: convenience script for quick, local deployment

### DIFF
--- a/scripts/local_deploy.py
+++ b/scripts/local_deploy.py
@@ -20,14 +20,14 @@ def stop_greengrass() -> None:
     if os.name == 'nt':
         subprocess.call(['net', 'stop', 'greengrass'])  # allow failure, service may already be stopped
     else:
-        subprocess.check_call(['systemctl', 'stop', 'greengrass'])
+        raise NotImplementedError('unix not yet supported')
 
 
 def start_greengrass() -> None:
     if os.name == 'nt':
         subprocess.check_call(['net', 'start', 'greengrass'])
     else:
-        subprocess.check_call(['systemctl', 'start', 'greengrass'])
+        raise NotImplementedError('unix not yet supported')
 
 
 class ValidationException(Exception):
@@ -98,6 +98,9 @@ class LocalDeployer:
 
 
 if __name__ == '__main__':
+    if os.name != 'nt':
+        raise NotImplementedError('unix/docker not yet supported')
+
     parser = argparse.ArgumentParser(description='Deploy emqx component locally to greengrass core device. '
                                                  'The latest component version in artifacts-unarchived will be '
                                                  'replaced with contents of emqx.zip. NOTE: This script will only work'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Script to easily deploy `emqx.zip` artifact to the local core device.  This reduces development time by removing the need for a full cloud deployment (after an initial one has been done already).

Example usage:
```
# build the project
python -u -m bin --quick
# deploy emqx.zip to local device without performing full cloud deploy
./scripts/local_deploy.py
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
