### PR TITLE
feat: restart when read-only configs change

### DIFF
--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -167,7 +167,6 @@ update_conf(ExistingOverrideConf, NewComponentConf) ->
   end,
 
   OverrideConf = get_override_conf(NewConf),
-  %% TODO detect change of non-reloadable conf
   logger:debug("Updating emqx override config. existing=~p, override=~p", [ExistingConf, OverrideConf]),
   case catch update_override_conf(ExistingConf, OverrideConf) of
     ok -> put_verify_fun();

--- a/recipe.json
+++ b/recipe.json
@@ -63,7 +63,10 @@
           "EMQX_LOG__CONSOLE__LEVEL": "{configuration:/emqx/log.level}",
           "IPC_TIMEOUT_SECONDS": "{configuration:/ipcTimeoutSeconds}",
           "RESTART_IDENTIFIER": "{configuration:/restartIdentifier}",
-          "CRT_LOG_LEVEL": "{configuration:/crtLogLevel}"
+          "CRT_LOG_LEVEL": "{configuration:/crtLogLevel}",
+          "RESTART_NODE_CONF": "{configuration:/emqxConfig/node}",
+          "RESTART_CLUSTER_CONF": "{configuration:/emqxConfig/cluster}",
+          "RESTART_RPC_CONF": "{configuration:/emqxConfig/rpc}"
         },
         "shutdown": {
           "script": "{artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd stop"
@@ -99,7 +102,10 @@
             "EMQX_LOG__CONSOLE__LEVEL": "{configuration:/emqx/log.level}",
             "RESTART_IDENTIFIER": "{configuration:/restartIdentifier}",
             "CRT_LOG_LEVEL":  "{configuration:/crtLogLevel}",
-            "IPC_TIMEOUT_SECONDS": "{configuration:/ipcTimeoutSeconds}"
+            "IPC_TIMEOUT_SECONDS": "{configuration:/ipcTimeoutSeconds}",
+            "RESTART_NODE_CONF": "{configuration:/emqxConfig/node}",
+            "RESTART_CLUSTER_CONF": "{configuration:/emqxConfig/cluster}",
+            "RESTART_RPC_CONF": "{configuration:/emqxConfig/rpc}"
           }
         },
         "shutdown": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Restart broker when read-only configs, **cluster**, **rpc**, and **node** change, via recipe interpolation.

*Testing:*

Set the following configs, in order, and verified that the component restarted in each case:

```
{
   "emqxConfig: {
       "node": {
            "someKey": 1
       }
    }
}
```
```
{
   "emqxConfig: {
       "node": {
            "someKey": 2
       }
    }
}
```

Validates that sub-configs under node will trigger restart

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
