### PR TITLE
refactor: fetch configs only once on startup, get certs first

### DIFF
--- a/gg/src/gg_certs.erl
+++ b/gg/src/gg_certs.erl
@@ -5,34 +5,71 @@
 
 -module(gg_certs).
 
--export([request_certificates/0]).
+-export([start/0, stop/0]).
+-export([request_certificates/0, do_receive_certificate_requests/0]).
+
+-define(ENV_APP, aws_greengrass_emqx_auth). %% TODO rename all to gg
 
 -define(CERT_LOAD_TIMEOUT_MILLIS, 300000). %% 5 minutes
 
--define(REQUEST_CERTS_PROC, gg_request_certificates).
--define(CERTS_UPDATED, certs_updated).
+start() ->
+  receive_certificate_requests().
+
+stop() ->
+  certificate_request_receiver ! stop.
 
 %% Request that CDA generate server certificates for EMQX to use.
 %% On completion of this function, certificates will be written
 %% to the EMQX component work directory, where the EMQX ssl listener
 %% is configured to read certs from.
 request_certificates() ->
-  request_certificates(gg_conf:use_greengrass_managed_certificates()).
-request_certificates(Enabled) when Enabled == true ->
-  register(?REQUEST_CERTS_PROC, self()),
+  certificate_request_receiver ! {request_certificates, self()},
+  receive
+    certs_updated -> ok;
+    ignore -> ignore
+  after ?CERT_LOAD_TIMEOUT_MILLIS ->
+    exit({error, "Timed out waiting for certificate update"})
+  end.
+
+receive_certificate_requests() ->
+  ListenPID = spawn(?MODULE, do_receive_certificate_requests, []),
+  register(certificate_request_receiver, ListenPID).
+
+do_receive_certificate_requests() ->
+  receive
+    {request_certificates, Caller} ->
+      do_request_certificates(Caller),
+      do_receive_certificate_requests();
+    stop -> ok
+  end.
+
+%% TODO for completeness, we should implement unsubscribe from cert requests and delete certs from config = false
+
+do_request_certificates(Caller) ->
+  do_request_certificates(application:get_env(?ENV_APP, certificates_requested, false), Caller).
+do_request_certificates(_Requested = true, Caller) ->
+  logger:debug("Ignoring certificate update request."),
+  Caller ! ignore;
+do_request_certificates(_Requested = false, Caller) ->
+  logger:info("Certificate update request received"),
+  register_listener(Caller),
   gg_port_driver:register_fun(certificate_update, fun on_cert_update/0),
   gg_port_driver:request_certificates(),
-  receive
-    ?CERTS_UPDATED -> ok
-  after ?CERT_LOAD_TIMEOUT_MILLIS ->
-    exit({error, "Timed out waiting for requested server certificates"})
-  end;
-request_certificates(Enabled) when Enabled == false ->
-  ok.
+  application:set_env(?ENV_APP, certificates_requested, true).
+
+register_listener(Pid) ->
+  application:set_env(?ENV_APP, on_cert_update, Pid).
+
+trigger_listener() ->
+  trigger_listener(application:get_env(?ENV_APP, on_cert_update, undefined)).
+trigger_listener(Pid) when is_pid(Pid) ->
+  Pid ! certs_updated;
+trigger_listener(_) ->
+  pass.
 
 on_cert_update() ->
   case catch emqx_mgmt:clean_pem_cache_all() of
     ok -> logger:info("PEM cache cleared");
     Err -> logger:warning("Unable to clear PEM cache: ~p", [Err])
   end,
-  ?REQUEST_CERTS_PROC ! ?CERTS_UPDATED.
+  trigger_listener().


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we perform two config updates on startup.  This was a workaround to get `listeners` config update to stick because we needed to wait until certs were fetched by CDA. The reason for workaround was because there was a bit of a chicken-and-egg problem: cert update relied on plugin config value, config update relied on certs being present.

This PR replaces the workaround, where we fetch certificates BEFORE we perform the config update, and we only perform a single config update on startup instead of two.

*Testing:*
* Start with clean environment (no work dir, no certs, etc)
* Deploy with default configuration (GG auth enabled, certs enabled)
* Verify that listeners updated on config update `2023-07-24T20:28:41.144Z [INFO] (Copier) aws.greengrass.clientdevices.mqtt.EMQX: stdout. load listeners in cluster ok. {scriptName=services.aws.greengrass.clientdevices.mqtt.EMQX.lifecycle.startup.script, serviceName=aws.greengrass.clientdevices.mqtt.EMQX, currentState=RUNNING}
`.
* Verify that ggad can send messages through the broker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
