### PR TITLE
fix: add missing emqx_authn in patch file

### DIFF
--- a/patches/emqx_plugins.app.src
+++ b/patches/emqx_plugins.app.src
@@ -6,6 +6,6 @@
   {mod, {emqx_plugins_app, []}},
   %% gg plugin relies on emqx_authn, so we need it to start
   %% BEFORE plugins are loaded
-  {applications, [kernel, stdlib, emqx]},
+  {applications, [kernel, stdlib, emqx, emqx_authn]},
   {env, []}
 ]}.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Forgot to add `emqx_authn` in https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/180.  The previous PR was tested with this value set, just forgot to include it in the PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
