### PR TITLE
fix(write_config): proper usage of string erase

### DIFF
--- a/port_driver/write_config/write_config.cpp
+++ b/port_driver/write_config/write_config.cpp
@@ -170,11 +170,11 @@ int read_config_and_update_files(GreengrassIPCWrapper &ipc) {
     // as seen during our testing, HOCON won't support multiple JSON docs in a single file.
     auto opening_brace = output.find_first_of('{');
     if (opening_brace != std::string::npos) {
-        output.erase(opening_brace);
+        output.erase(opening_brace, 1);
     }
     auto closing_brace = output.find_last_of('}');
     if (closing_brace != std::string::npos) {
-        output.erase(closing_brace);
+        output.erase(closing_brace, 1);
     }
 
     LOG_I(WRITE_CONFIG_SUBJECT, "Writing configuration to %s", emqx_conf.string().c_str());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix write_config so that it properly removes "{" and "}" from configuration before appending to emqx.conf. Before it was erasing the entire configuration string and just appending empty string

*Testing:*
* Validated that gg configuration is appended to etc/emqx.conf
* Validated that without erasing "{" and "}" that emqx does not start up due to bad emqx.conf file format

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
