### PR TITLE
fix: ssl erroring when listener not restarted

### DIFF
--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -203,7 +203,8 @@ put_verify_fun(AuthMode) when AuthMode =/= bypass ->
     Err -> logger:error("Failed to set listener verify fun: ~p", [Err])
   end;
 put_verify_fun(_AuthMode) ->
-  skip.
+  %% TODO only do this workaround on startup? listener restarts will disconnect clients
+  emqx_listeners:restart_listener(ssl, default, gg_listeners:get_listener_config(ssl, default)).
 
 %%--------------------------------------------------------------------
 %% Update Plugin Config

--- a/gg/src/gg_listeners.erl
+++ b/gg/src/gg_listeners.erl
@@ -5,7 +5,7 @@
 
 -module(gg_listeners).
 
--export([put_verify_fun/3]).
+-export([put_verify_fun/3, get_listener_config/2]).
 
 %% Set verify_fun erlang ssl option on a listener.
 %% Listener is restarted for changes to take effect.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have an error in one of our UATs where ssl handshake fails when ggad attempts to connect. This appears to happen when the ssl listener is NOT restarted during initial startup of the component.

*Testing:*
Ran currently failing UAT with changes and it's now passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
