### PR TITLE
chore: remove useGreengrassManagedCerts flag

### DIFF
--- a/gg/src/gg_app.erl
+++ b/gg/src/gg_app.erl
@@ -15,7 +15,6 @@ start(_StartType, _StartArgs) ->
   {ok, Sup} = gg_sup:start_link(),
   gg_port_driver:start(),
   gg_certs:start(),
-  gg_conf:register_config_change_handler(<<"useGreengrassManagedCertificates">>, fun on_use_greengrass_managed_certificates_change/1),
   gg_conf:start(),
   gg:load(application:get_all_env()),
   {ok, Sup}.
@@ -25,9 +24,3 @@ stop(_State) ->
   gg_conf:stop(),
   gg:unload(),
   gg_port_driver:stop().
-
-on_use_greengrass_managed_certificates_change(_NewValue = true) ->
-  gg_certs:request_certificates();
-on_use_greengrass_managed_certificates_change(_) ->
-  %% TODO delete certs?
-  pass.

--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -5,16 +5,15 @@
 
 -module(gg_conf).
 
--export([auth_mode/0, use_greengrass_managed_certificates/0]).
+-export([auth_mode/0]).
 
 -export([start/0, stop/0]).
 -export([receive_conf_updates/0, do_receive_conf_updates/0, request_update/0, request_update_sync/0]).
 -export([register_config_change_handler/2]).
 
 -type(auth_mode() :: enabled | bypass_on_failure | bypass).
--type(use_greengrass_managed_certificates() :: true | false).
 
--export_type([auth_mode/0, use_greengrass_managed_certificates/0]).
+-export_type([auth_mode/0]).
 
 -define(CONF_TIMEOUT_MILLIS, 30000).
 
@@ -24,10 +23,8 @@
 %% config keys
 -define(KEY_EMQX_CONFIG, <<"emqxConfig">>).
 -define(KEY_AUTH_MODE, <<"authMode">>).
--define(KEY_USE_GREENGRASS_MANAGED_CERTIFICATES, <<"useGreengrassManagedCertificates">>).
 %% defaults
 -define(DEFAULT_AUTH_MODE, enabled).
--define(DEFAULT_USE_GREENGRASS_MANAGED_CERTIFICATES, true).
 
 -define(SCHEMA_ROOT, list_to_binary(gg_schema:namespace())).
 
@@ -49,10 +46,6 @@
 -spec(auth_mode() -> auth_mode()).
 auth_mode() ->
   application:get_env(?ENV_APP, ?KEY_AUTH_MODE, ?DEFAULT_AUTH_MODE).
-
--spec(use_greengrass_managed_certificates() -> use_greengrass_managed_certificates()).
-use_greengrass_managed_certificates() ->
-  application:get_env(?ENV_APP, ?KEY_USE_GREENGRASS_MANAGED_CERTIFICATES, ?DEFAULT_USE_GREENGRASS_MANAGED_CERTIFICATES).
 
 %%--------------------------------------------------------------------
 %% On Config Change Callbacks
@@ -225,8 +218,7 @@ validate_plugin_conf(PluginConf) ->
   end.
 
 update_plugin_conf(PluginConf) ->
-  update_plugin_conf(PluginConf, ?KEY_AUTH_MODE, ?DEFAULT_AUTH_MODE),
-  update_plugin_conf(PluginConf, ?KEY_USE_GREENGRASS_MANAGED_CERTIFICATES, ?DEFAULT_USE_GREENGRASS_MANAGED_CERTIFICATES).
+  update_plugin_conf(PluginConf, ?KEY_AUTH_MODE, ?DEFAULT_AUTH_MODE).
 
 update_plugin_conf(PluginConf, Key, Default) ->
   PrevVal = application:get_env(?ENV_APP, Key, undefined),

--- a/gg/src/gg_schema.erl
+++ b/gg/src/gg_schema.erl
@@ -29,14 +29,5 @@ fields("gg") ->
           required => false,
           desc => "Auth mode"
         }
-      )},
-    {useGreengrassManagedCertificates,
-      ?HOCON(
-        boolean(),
-        #{
-          default => true,
-          required => false,
-          desc => "Use greengrass managed certificates"
-        }
       )}
   ].


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove `useGreengrassManagedCerts` flag.  Our plugin will always fetch certs on startup now, customer can choose to use them or not by modifying emqx's ssl listener settings.

See https://github.com/aws-greengrass/aws-greengrass-emqx-mqtt/pull/185 for motivation behind this change

*Testing*
With clean installation, confirm that cert.pem and key.pem are written to work directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
