### PR TITLE
feat: script for leak testing config changes

### DIFF
--- a/scripts/config_changer.py
+++ b/scripts/config_changer.py
@@ -71,10 +71,13 @@ class LocalDeployer:
         for i in range(10):
             if i == 0:
                 print('waiting for deployment to complete...')
-            resp = subprocess.check_output([
-                'greengrass-cli.cmd', 'deployment', 'status',
-                '-i', deployment_id
-            ])
+            try:
+                resp = subprocess.check_output([
+                    'greengrass-cli.cmd', 'deployment', 'status',
+                    '-i', deployment_id
+                ])
+            except subprocess.CalledProcessError:
+                continue
             deployment_status = resp.strip().split()[-1].decode('utf-8')
             print(deployment_status)
             if deployment_status == 'FAILED':


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a script to send config changes to emqx via a local deployment.  Designed for leak testing our configuration-change code path.

Strategy:
For first, simple implementation, just alternate between two different configurations, repeatedly.

*Testing:*
```
$./scripts/config_changer.py
deployment 651f733a-8022-4c1b-a839-80d05b8c4bd0 created 
waiting for deployment to complete... 
QUEUED 
QUEUED 
IN_PROGRESS 
IN_PROGRESS 
SUCCEEDED 
...
rest of output omitted
```
confirmed in emqx logs that a config change was received and processed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
