### PR TITLE
chore: remove unused configs

### DIFF
--- a/patches/emqx.conf
+++ b/patches/emqx.conf
@@ -14,6 +14,12 @@ listeners {
     }
 }
 
+log {
+    console {
+        enable = true
+    }
+}
+
 authorization {
   no_match = deny
   sources = []

--- a/port_driver/common.cpp
+++ b/port_driver/common.cpp
@@ -31,28 +31,3 @@ aws_log_level crtStringToLogLevel(const std::string &level) {
     // Default to warn
     return AWS_LL_WARN;
 }
-
-aws_log_level erlangStringToLogLevel(const std::string &level) {
-    // Erlang log levels
-    // debug, info, notice, warning, error, critical, alert, emergency
-    if (level == "debug") {
-        return AWS_LL_TRACE;
-    }
-    if (level == "info") {
-        return AWS_LL_DEBUG;
-    }
-    if (level == "notice") {
-        return AWS_LL_INFO;
-    }
-    if (level == "warning") {
-        return AWS_LL_WARN;
-    }
-    if (level == "error") {
-        return AWS_LL_ERROR;
-    }
-    if (level == "emergency") {
-        return AWS_LL_FATAL;
-    }
-    // Default to warn
-    return AWS_LL_WARN;
-}

--- a/port_driver/port_driver.cpp
+++ b/port_driver/port_driver.cpp
@@ -33,7 +33,6 @@ struct atoms {
     ErlDrvTermData configuration_update;
 };
 static struct atoms ATOMS {};
-static const char *EMQX_LOG_LEVEL_ENV_VAR = "EMQX_LOG__CONSOLE_HANDLER__LEVEL";
 static const char *EMQX_DATA_ENV_VAR = "EMQX_NODE__DATA_DIR";
 static const char *CRT_LOG_LEVEL_ENV_VAR = "CRT_LOG_LEVEL";
 
@@ -46,9 +45,7 @@ EXPORTED ErlDrvData drv_start(ErlDrvPort port, [[maybe_unused]] char *buff) { //
         // Use CRT_LOG_LEVEL when it is provided a non-empty
         awsLogLevel = crtStringToLogLevel(crtLogLevel);
     } else {
-        // Otherwise, get the log level from the EMQX log level envvar
-        const char *logLevel = std::getenv(EMQX_LOG_LEVEL_ENV_VAR); // Log level may be null or empty
-        awsLogLevel = erlangStringToLogLevel(logLevel == nullptr ? "" : logLevel);
+        awsLogLevel = AWS_LL_WARN;
     }
 
     struct aws_logger_standard_options logger_options = {

--- a/port_driver/write_config/write_config.cpp
+++ b/port_driver/write_config/write_config.cpp
@@ -12,7 +12,6 @@
 #include <variant>
 
 static const char *CRT_LOG_LEVEL_ENV_VAR = "CRT_LOG_LEVEL";
-static const char *EMQX_LOG_LEVEL_ENV_VAR = "EMQX_LOG__CONSOLE_HANDLER__LEVEL";
 static const char *ORIGINAL_EMQX_DATA_DIR_ENV_VAR = "ORIG_EMQX_NODE__DATA_DIR";
 static const char *ORIGINAL_EMQX_ETC_DIR_ENV_VAR = "ORIG_EMQX_NODE__ETC_DIR";
 static const char *EMQX_DATA_DIR_ENV_VAR = "EMQX_NODE__DATA_DIR";
@@ -65,9 +64,7 @@ void setup_logger() {
         // Use CRT_LOG_LEVEL when it is provided a non-empty
         awsLogLevel = crtStringToLogLevel(crtLogLevel);
     } else {
-        // Otherwise, get the log level from the EMQX log level envvar
-        const char *logLevel = getenv(EMQX_LOG_LEVEL_ENV_VAR); // Log level may be null or empty
-        awsLogLevel = erlangStringToLogLevel(logLevel == nullptr ? "" : logLevel);
+        awsLogLevel = AWS_LL_WARN;
     }
     struct aws_logger_standard_options logger_options = {
         .level = awsLogLevel,

--- a/recipe.json
+++ b/recipe.json
@@ -6,11 +6,6 @@
   "ComponentPublisher": "AWS",
   "ComponentConfiguration": {
     "DefaultConfiguration": {
-      "emqx": {
-        "log.enabled": "true",
-        "log.level": "debug",
-        "listener.ssl.default.bind": "8883"
-      },
       "accessControl": {
         "aws.greengrass.clientdevices.Auth": {
           "aws.greengrass.clientdevices.mqtt.EMQX:auth:1": {
@@ -27,6 +22,7 @@
           }
         }
       },
+      "dockerOptions": "-p 8883:8883",
       "crtLogLevel": "",
       "requiresPrivilege": "true",
       "restartIdentifier": "",
@@ -56,11 +52,8 @@
           "ORIG_EMQX_NODE__ETC_DIR": "{artifacts:decompressedPath}\\emqx\\emqx\\etc",
           "EMQX_NODE__DATA_DIR": "{work:path}\\data",
           "EMQX_NODE__ETC_DIR": "{work:path}\\etc",
-          "EMQX_LISTENERS__SSL__DEFAULT__BIND": "{configuration:/emqx/listener.ssl.default.bind}",
           "EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__KEYFILE": "{work:path}\\data\\key.pem",
           "EMQX_LISTENERS__SSL__DEFAULT__SSL_OPTIONS__CERTFILE": "{work:path}\\data\\cert.pem",
-          "EMQX_LOG__CONSOLE__ENABLE": "{configuration:/emqx/log.enabled}",
-          "EMQX_LOG__CONSOLE__LEVEL": "{configuration:/emqx/log.level}",
           "IPC_TIMEOUT_SECONDS": "{configuration:/ipcTimeoutSeconds}",
           "RESTART_IDENTIFIER": "{configuration:/restartIdentifier}",
           "CRT_LOG_LEVEL": "{configuration:/crtLogLevel}",
@@ -95,11 +88,10 @@
         "startup": {
           "requiresPrivilege": "{configuration:/requiresPrivilege}",
           "timeout": "{configuration:/startupTimeoutSeconds}",
-          "script": "docker run --rm --name emqx -p {configuration:/emqx/listener.ssl.default.bind}:{configuration:/emqx/listener.ssl.default.bind} -v $AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:$AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT -e SVCUID -e AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT -e EMQX_LISTENERS__SSL__DEFAULT__BIND -e EMQX_LOG__CONSOLE__ENABLE -e EMQX_LOG__CONSOLE__LEVEL -e CRT_LOG_LEVEL -e IPC_TIMEOUT_SECONDS -e RESTART_IDENTIFIER aws-greengrass-emqx:amd64",
+          "script": "case $DOCKER_EXTRA in \\{configuration:*) DOCKER_EXTRA=\"\";; esac; docker run --rm --name emqx $DOCKER_EXTRA -v $AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT:$AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT -e SVCUID -e AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT -e EMQX_LISTENERS__SSL__DEFAULT__BIND -e CRT_LOG_LEVEL -e IPC_TIMEOUT_SECONDS -e RESTART_IDENTIFIER aws-greengrass-emqx:amd64",
           "setEnv": {
+            "DOCKER_EXTRA": "{configuration:/dockerOptions}",
             "EMQX_LISTENERS__SSL__DEFAULT__BIND": "{configuration:/emqx/listener.ssl.default.bind}",
-            "EMQX_LOG__CONSOLE__ENABLE": "{configuration:/emqx/log.enabled}",
-            "EMQX_LOG__CONSOLE__LEVEL": "{configuration:/emqx/log.level}",
             "RESTART_IDENTIFIER": "{configuration:/restartIdentifier}",
             "CRT_LOG_LEVEL":  "{configuration:/crtLogLevel}",
             "IPC_TIMEOUT_SECONDS": "{configuration:/ipcTimeoutSeconds}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* `/emqx` config key removed
* default log level set in `emqx.conf` now
* crt log level defaults to warn rather than emqx log level
* port settings moved into dockerOptions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
