### PR TITLE
fix: missing quotes around windows paths for the startup script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           python3 -u -m bin --port-driver-only
           python3 -u -m bin --quick
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Build artifact ${{matrix.os}}
           path: build/emqx.zip

--- a/recipe.json
+++ b/recipe.json
@@ -43,7 +43,7 @@
       },
       "Lifecycle": {
         "startup": {
-          "script": "{artifacts:decompressedPath}\\emqx\\emqx\\plugins\\gg-1.0.0\\gg-1.0.0\\priv\\write_config.exe && {artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd console",
+          "script": "\"{artifacts:decompressedPath}\\emqx\\emqx\\plugins\\gg-1.0.0\\gg-1.0.0\\priv\\write_config.exe\" && \"{artifacts:decompressedPath}\\emqx\\emqx\\bin\\emqx.cmd\" console",
           "timeout": "{configuration:/startupTimeoutSeconds}"
         },
         "setEnv": {


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* 
On 2025/02/25, We got a customer ticket about failed to deploy the EMQX component. After adding quotes around windows paths in the recipe, we could successfully proceed running and deployment remains healthy. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
