### PR TITLE
fix: parse windows paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019] # windows-latest does not have visual studio 2017
+        os: [ubuntu-20.04, windows-2022]
         otp: ['24.0']
     steps:
       - uses: actions/checkout@v3

--- a/patches/emqx.cmd.diff
+++ b/patches/emqx.cmd.diff
@@ -67,7 +67,7 @@
 +:: )
 +:: [greengrass patch end]
 
- @set conf_path="%etc_dir%\emqx.conf"
+ @set conf_path=%etc_dir%\emqx.conf
 
 -@for /f "usebackq tokens=1,2 delims==" %%a in (`"%escript% %nodetool% hocon -s %schema_mod% -c %conf_path% multi_get node.name node.cookie node.data_dir"`) do @(
 -  if "%%a"=="node.name" set node_name=%%b
@@ -78,7 +78,7 @@
 +:: remove data dir looking from config file,
 +:: use env vars for data dir since that's how
 +:: greengrass exposes user configuration
-+@for /f "usebackq tokens=1,2 delims==" %%a in (`"%escript% %nodetool% hocon -s %schema_mod% -c %conf_path% multi_get node.name node.cookie"`) do @(
++@for /f "usebackq tokens=1,2 delims==" %%a in (`"%escript% %nodetool% hocon -s %schema_mod% -c "%conf_path%" multi_get node.name node.cookie"`) do @(
 +   if "%%a"=="node.name" set node_name=%%b
 +   if "%%a"=="node.cookie" set node_cookie=%%b
 + )

--- a/port_driver/CMakeLists.txt
+++ b/port_driver/CMakeLists.txt
@@ -34,6 +34,18 @@ execute_process(
 message("Erlang libs directory found: ${ERL_LIBS}")
 
 include_directories("include")
+#
+# Suppress unreferenced-parameter warnings coming from third-party/submodule code:
+# - MSVC: disable C4100 (unreferenced formal parameter)
+# - GCC/Clang: disable -Wunused-parameter
+if (MSVC)
+    # Ignore unreferenced parameter warning in MSVC (C4100)
+    add_compile_options("/wd4100")
+else()
+    # Ignore unused parameter warnings for GCC/Clang
+    add_compile_options("-Wno-unused-parameter")
+endif()
+
 add_subdirectory(cda_integration)
 
 if (CLANG_TIDY)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EMQX by itself does not recognize Windows paths and our current patch is unable to correctly inject paths with spaces in it. This patch update should allow for correct path injection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
