### PR TITLE
fix: re-inject verify_fun after config-driven listener restarts

### DIFF
--- a/gg/src/gg_conf.erl
+++ b/gg/src/gg_conf.erl
@@ -6,6 +6,7 @@
 -module(gg_conf).
 
 -export([auth_mode/0]).
+-export([post_config_update/5]).
 
 -export([start/0, stop/0]).
 -export([receive_conf_updates/0, do_receive_conf_updates/0, request_update/0, request_update_sync/0]).
@@ -97,12 +98,14 @@ start() ->
   end,
   receive_conf_updates(),
   gg_port_driver:subscribe_to_configuration_updates(fun request_update/0),
+  emqx_config_handler:add_handler([listeners, ssl, default], ?MODULE),
   case request_update_sync() of
     ok -> ok;
     Error -> exit(Error)
   end.
 
 stop() ->
+  emqx_config_handler:remove_handler([listeners, ssl, default]),
   ?UPDATE_PROC ! stop.
 
 receive_conf_updates() ->
@@ -198,6 +201,17 @@ put_verify_fun(AuthMode) when AuthMode =/= bypass ->
 put_verify_fun(_AuthMode) ->
   %% TODO only do this workaround on startup? listener restarts will disconnect clients
   emqx_listeners:restart_listener(ssl, default, gg_listeners:get_listener_config(ssl, default)).
+
+%%--------------------------------------------------------------------
+%% Config Change Handler
+%%--------------------------------------------------------------------
+
+%% Called by emqx_config_handler after any config update to the SSL listener.
+%% Re-injects verify_fun which is lost on every listener restart because
+%% it is an in-memory Erlang fun that cannot be serialized to hocon config.
+post_config_update(_Path, _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
+  put_verify_fun(),
+  ok.
 
 %%--------------------------------------------------------------------
 %% Update Plugin Config


### PR DESCRIPTION
## Summary

Fixes a race condition where `verify_fun` is lost after `emqx_conf_cli:load_config(..., replace)` schedules an async listener restart that overwrites the injection from `put_verify_fun()`.

## Root Cause

`verify_fun` (`gg_tls:verify_client_certificate/3`) is an in-memory Erlang closure that cannot be serialized to EMQX's hocon config. When `update_override_conf/2` calls `load_config`, it returns `ok` immediately but schedules a deferred listener restart. `put_verify_fun()` then injects `verify_fun` by restarting the listener. The deferred restart fires after, reading config from `cluster.hocon` (no `verify_fun`), and starts the listener fresh — wiping `verify_fun`.

## Fix

Register `gg_conf` as an `emqx_config_handler` for the `[listeners, ssl, default]` config path. EMQX calls `post_config_update/5` synchronously after every config-driven listener restart completes. The callback calls `put_verify_fun()`, guaranteeing re-injection after every restart.

## Changes

- Export `post_config_update/5`
- Register handler in `start()`: `emqx_config_handler:add_handler([listeners, ssl, default], ?MODULE)`
- Deregister in `stop()`
- Implement `post_config_update/5` callback that calls `put_verify_fun()`

## Testing

Reproduced on EC2 (Greengrass 2.17.0, EMQX 2.0.3, CDA 2.5.6):
- Fresh deployment: `verify_fun` confirmed missing, TLS fails
- Triggered `load_config` race manually: `verify_fun` wiped 100% of the time
- With fix (simulated via polling monitor): `verify_fun` survives repeated races

## Ticket

P444364881