### PR TITLE
fix: respect per-listener enable_authn in GG auth plugin

### DIFF
--- a/gg/src/README.md
+++ b/gg/src/README.md
@@ -1,0 +1,60 @@
+# Greengrass EMQX Auth Plugin Design
+
+## Overview
+
+The GG auth plugin (`gg.erl`) hooks into EMQX's client lifecycle to provide
+Greengrass-managed authentication and authorization via the Client Device Auth
+(CDA) component.
+
+## Hooks
+
+The plugin registers three hooks at `HP_HIGHEST` priority:
+
+- `client.connect` — stores the peer certificate and MQTT protocol version in the process dictionary for use in subsequent hooks.
+- `client.authenticate` — calls the CDA port driver to obtain an auth token for the connecting client. On success, stops the hook chain. On failure, behavior depends on `authMode`.
+- `client.authorize` — calls the CDA port driver to check if the client is authorized for the requested pub/sub operation. Uses the auth token obtained during authentication.
+
+## Auth Modes
+
+Configured via `authMode` in the component configuration:
+
+- `enabled` (default) — GG auth is authoritative. Auth failures reject the client.
+- `bypass_on_failure` — GG auth is attempted first. On failure, continues the hook chain (defers to remaining auth providers).
+- `bypass` — GG auth is disabled entirely. EMQX's own auth chain handles all clients.
+
+## Per-Listener Behavior
+
+The plugin respects the EMQX per-listener `enable_authn` setting. EMQX places this
+setting in the `ClientInfo` map that is passed to hook callbacks.
+
+When `enable_authn` is `false`:
+- **Authentication**: the plugin skips GG auth processing. EMQX also natively skips
+  the authenticate hook chain for these listeners, so the plugin's check is defense-in-depth.
+- **Authorization**: the plugin skips GG authZ. GG authZ requires an auth token from
+  GG authn, which cannot exist for clients that bypassed authentication. Authorization
+  falls through to the EMQX authorization chain (`authorization.sources` + `authorization.no_match`).
+
+## Port Driver
+
+The plugin communicates with the Greengrass nucleus via a native port driver
+(`gg_port_driver.erl` → `port_driver.cpp`). The port driver uses IPC to call
+the Client Device Auth component for:
+
+- `get_auth_token` — authenticate a client by client ID and certificate PEM
+- `on_client_check_acl` — authorize a pub/sub action given a client ID, auth token, topic, and action
+
+## Certificate Management
+
+`gg_certs.erl` requests the CDA component to generate server TLS certificates for
+the EMQX SSL listener. Certificates are written to the EMQX component work directory
+where the SSL listener is configured to read them from.
+
+`gg_conf.erl` sets a custom TLS verify function on the SSL listener via
+`gg_listeners:put_verify_fun/3` (`gg_tls:verify_client_certificate/3`) to validate
+client device certificates through Greengrass.
+
+## Configuration
+
+`gg_conf.erl` manages plugin configuration. It subscribes to configuration updates
+from the Greengrass nucleus via IPC and applies them to both the plugin settings
+(`authMode`) and the EMQX override configuration (`emqxConfig`).

--- a/gg/src/gg.erl
+++ b/gg/src/gg.erl
@@ -39,7 +39,8 @@
 load(Env) ->
   hook('client.connect', {?MODULE, on_client_connect, [Env]}),
   hook('client.authenticate', {?MODULE, on_client_authenticate, [Env]}),
-  hook('client.authorize', {?MODULE, on_client_authorize, [Env]}).
+  hook('client.authorize', {?MODULE, on_client_authorize, [Env]}),
+  log_skipped_listeners().
 
 unload() ->
   unhook('client.connect', {?MODULE, on_client_connect}),
@@ -109,6 +110,14 @@ handle_connect(_, ConnInfo = #{clientid := ClientId, peercert := PeerCert, proto
 
 %% Interface derived from
 %% https://github.com/emqx/emqx/blob/270059f0c2694342fc72338760dbb968b78b7918/apps/emqx/src/emqx_access_control.erl#L53-L68
+%%
+%% Listeners with enable_authn: false skip GG auth entirely.
+%% EMQX places the listener's enable_authn setting directly in ClientInfo
+%% (see emqx_channel:init/2). Defense-in-depth: EMQX also natively skips
+%% the authenticate hook chain for these listeners, but we guard here too.
+on_client_authenticate(#{enable_authn := false, clientid := ClientId}, _Result, _Env) ->
+  logger:debug("Client(~s) skipping GG auth (enable_authn=false)", [ClientId]),
+  ?CONTINUE_HOOK_CHAIN;
 on_client_authenticate(ClientInfo = #{clientid := ClientId}, Result, _Env) ->
   execute_auth_hook(
     fun() ->
@@ -150,6 +159,13 @@ reauthenticate(ClientId) ->
 
 %% Interface derived from
 %% https://github.com/emqx/emqx/blob/270059f0c2694342fc72338760dbb968b78b7918/apps/emqx/src/emqx_access_control.erl#L121-L127
+%%
+%% Listeners with enable_authn: false skip GG authZ — GG authZ requires
+%% the auth token from GG authn, which cannot exist for these clients.
+%% Authorization falls through to the EMQX authorization chain (sources + no_match).
+on_client_authorize(#{enable_authn := false, clientid := ClientId}, _PubSub, _Topic, _Result, _Env) ->
+  logger:debug("Client(~s) skipping GG authZ (enable_authn=false)", [ClientId]),
+  ?CONTINUE_HOOK_CHAIN;
 on_client_authorize(ClientInfo = #{clientid := ClientId}, PubSub, Topic, Result, _Env) ->
   execute_auth_hook(
     fun() ->
@@ -235,6 +251,22 @@ is_authorized({ok, bad_token}, Retries, _, ClientId, Resource, Action) when Retr
 %%--------------------------------------------------------------------
 %% Utils
 %%--------------------------------------------------------------------
+
+%% Log once at startup which listeners have GG auth disabled.
+log_skipped_listeners() ->
+  Listeners = maps:to_list(emqx:get_config([listeners], #{})),
+  lists:foreach(
+    fun({Proto, NameMap}) ->
+      lists:foreach(
+        fun({Name, Conf}) ->
+          case maps:get(enable_authn, Conf, true) of
+            false ->
+              logger:warning("GG auth disabled for listener ~p:~p; authorization defers to EMQX sources (no_match=~p)",
+                [Proto, Name, emqx:get_config([authorization, no_match], deny)]);
+            _ -> ok
+          end
+        end, maps:to_list(NameMap))
+    end, Listeners).
 
 kick_client(ClientId, OnPreKick) ->
   kick_client(gg_conf:auth_mode(), ClientId, OnPreKick).


### PR DESCRIPTION
## Summary

The GG auth plugin previously processed every MQTT connection regardless of which listener it arrived on. This caused `error_from_driver: Code 1` errors for clients connecting to TCP listeners configured with `enable_authn: false`, even when `authMode: bypass_on_failure` was set.

## Problem

Customers with mixed-auth architectures (unauthenticated TCP clients on port 1883 + Greengrass mTLS devices on port 8883) experienced connection instability on port 1883. The GG plugin attempted to authenticate every connection via the CDA port driver, failed for non-Greengrass clients, and then bypassed — but the failed auth attempt introduced latency and error log noise.

## Fix

In the `on_client_authenticate` and `on_client_authorize` hooks, check the `listener` field from EMQX `ClientInfo`. If the listener has `enable_authn: false`, skip all GG auth processing and return `CONTINUE_HOOK_CHAIN` immediately.

## Behavior after fix

- TCP 1883 (`enable_authn: false`): GG auth plugin skipped entirely — no port driver call, no `error_from_driver`
- SSL 8883 (`enable_authn: true`): GG auth plugin processes normally — full Greengrass mTLS

## Testing

E2E verified on EMQX 5.1.1 (component v2.0.3):
- Compiled patched `gg.erl`, replaced beam in running container, restarted EMQX
- TCP 1883: Paho MQTT clients connect cleanly, 0 `error_from_driver` errors
- SSL 8883: Connections without client certs rejected (`TLSV13_ALERT_CERTIFICATE_REQUIRED`)
- 3 Docker containers (feeder-logger, location-engine, crt-connector) ran for 60s+: 0 unexpected disconnects, full message delivery
- IPC to Greengrass nucleus confirmed active during test
