### PR TITLE
fix: bump aws-iot-device-sdk-cpp-v2 to v1.39.0

### DIFF
--- a/bin/build_sdk.py
+++ b/bin/build_sdk.py
@@ -22,6 +22,7 @@ def build_sdk(context):
         "-DCMAKE_INSTALL_PREFIX=.",
         f"-DCMAKE_BUILD_TYPE={context.cmake_build_type}",
         "-DBUILD_TESTING=OFF",
+        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
     ]
     cmake_configure_args.append("../aws-iot-device-sdk-cpp-v2")
     subprocess.check_call(cmake_configure_args)

--- a/port_driver/cda_integration/lib/CMakeLists.txt
+++ b/port_driver/cda_integration/lib/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # clang-format on
 cmake_minimum_required(VERSION 3.20)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 file(GLOB_RECURSE LIB_SRC "*.cpp")
 

--- a/port_driver/cda_integration/lib/cda_integration.cpp
+++ b/port_driver/cda_integration/lib/cda_integration.cpp
@@ -65,7 +65,7 @@ std::variant<int, std::unique_ptr<std::string>> ClientDeviceAuthIntegration::get
         return 1;
     }
 
-    auto resultFuture = getConfigOperation->GetOperationResult();
+    auto resultFuture = getConfigOperation->GetResult();
     if (resultFuture.wait_for(std::chrono::seconds(timeoutSeconds)) == std::future_status::timeout) {
         LOG_E(CDA_INTEG_SUBJECT, FAILED_TIMEOUT_ERROR_FMT, GET_CONFIGURATION_OP);
         return 1;
@@ -148,7 +148,7 @@ std::unique_ptr<std::string> ClientDeviceAuthIntegration::get_client_device_auth
         return {};
     }
 
-    auto responseFuture = operation->GetOperationResult();
+    auto responseFuture = operation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(timeoutSeconds)) == std::future_status::timeout) {
         LOG_E(CDA_INTEG_SUBJECT, FAILED_TIMEOUT_ERROR_FMT, GET_CLIENT_DEVICE_AUTH_TOKEN_OP);
         return {};
@@ -197,7 +197,7 @@ AuthorizationStatus ClientDeviceAuthIntegration::on_check_acl(const char *client
         return AuthorizationStatus::UNKNOWN_ERROR;
     }
 
-    auto responseFuture = authorizationOperation->GetOperationResult();
+    auto responseFuture = authorizationOperation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(timeoutSeconds)) == std::future_status::timeout) {
         LOG_E(CDA_INTEG_SUBJECT, FAILED_TIMEOUT_ERROR_FMT, AUTHORIZE_CLIENT_DEVICE_ACTION);
         return AuthorizationStatus::UNKNOWN_ERROR;
@@ -247,7 +247,7 @@ bool ClientDeviceAuthIntegration::verify_client_certificate(const char *certPem)
         return false;
     }
 
-    auto responseFuture = operation->GetOperationResult();
+    auto responseFuture = operation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(timeoutSeconds)) == std::future_status::timeout) {
         LOG_E(CDA_INTEG_SUBJECT, FAILED_TIMEOUT_ERROR_FMT, VERIFY_CLIENT_DEVICE_IDENTITY);
         return false;

--- a/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
+++ b/port_driver/cda_integration/lib/cert_generation/certificate_updater.cpp
@@ -127,7 +127,7 @@ CertSubscribeUpdateStatus CertificateUpdater::subscribeToUpdates(
     auto activate = operation->Activate(request, nullptr);
     activate.wait();
 
-    auto responseFuture = operation->GetOperationResult();
+    auto responseFuture = operation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(SUBSCRIBE_TIMEOUT_SECONDS)) == std::future_status::timeout) {
         LOG_E(CERT_UPDATER_SUBJECT, "Operation timed out while waiting for response from Greengrass Core.");
         return CertSubscribeUpdateStatus::SUBSCRIBE_ERROR_TIMEOUT_RESPONSE;

--- a/port_driver/cda_integration/lib/configuration_subscriber.cpp
+++ b/port_driver/cda_integration/lib/configuration_subscriber.cpp
@@ -39,7 +39,7 @@ ConfigurationSubscriber::subscribe_to_configuration_updates(std::unique_ptr<std:
     auto activate = operation->Activate(request, nullptr);
     activate.wait();
 
-    auto responseFuture = operation->GetOperationResult();
+    auto responseFuture = operation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(SUBSCRIBE_TIMEOUT_SECONDS)) == std::future_status::timeout) {
         LOG_E(CONFIG_SUBSCRIBER_SUBJECT, "Operation timed out while waiting for response from Greengrass Core.");
         return ConfigurationSubscribeStatus::SUBSCRIBE_ERROR_TIMEOUT_RESPONSE;

--- a/port_driver/cda_integration/lib/ipc/ipc_wrapper.cpp
+++ b/port_driver/cda_integration/lib/ipc/ipc_wrapper.cpp
@@ -62,5 +62,5 @@ void GreengrassIPCWrapper::setAsRunning() {
     request.SetState(Aws::Greengrass::REPORTED_LIFECYCLE_STATE_RUNNING);
     auto fut = operation->Activate(request, nullptr);
     fut.wait();
-    operation->GetOperationResult().wait_for(std::chrono::seconds(timeoutSeconds));
+    operation->GetResult().wait_for(std::chrono::seconds(timeoutSeconds));
 }

--- a/port_driver/write_config/write_config.cpp
+++ b/port_driver/write_config/write_config.cpp
@@ -89,7 +89,7 @@ std::variant<int, Aws::Crt::JsonObject> get_emqx_configuration(GreengrassIPCWrap
         return 1;
     }
 
-    auto responseFuture = operation->GetOperationResult();
+    auto responseFuture = operation->GetResult();
     if (responseFuture.wait_for(std::chrono::seconds(ipc.getTimeoutSeconds())) == std::future_status::timeout) {
         LOG_E(WRITE_CONFIG_SUBJECT, ClientDeviceAuthIntegration::FAILED_TIMEOUT_ERROR_FMT, GetConfigurationRequest);
         return 1;


### PR DESCRIPTION
## Summary
Bumps the AWS IoT Device SDK C++ v2 submodule from v1.35.2 to v1.39.0 to fix a crash (SIGSEGV / exit 139) in the EMQX Docker container on startup.

## Root Cause
SDK v1.35.2's EventStream RPC client has a bug in `ClientConnection::s_onConnectionSetup` (EventStreamClient.cpp) where the error path corrupts a `ByteBuf` inside a `MessageAmendment`, causing a segfault in its destructor when the IPC connection setup receives a non-zero error code.

## Fix
SDK v1.39.0 includes:
- PR #816 "Eventstream Refactor" — complete rewrite of EventStreamClient.cpp
- PR #826 "Greengrass IPC Refactor"

These eliminate the crashing code path entirely.

## Code changes
- Bump `aws-iot-device-sdk-cpp-v2` submodule to v1.39.0
- Rename `GetOperationResult()` -> `GetResult()` across all port driver code (renamed in the updated Greengrass IPC model)
- Add `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` to the SDK cmake build and to `cda_integration`'s CMakeLists.txt (needed so the SDK's static libs link cleanly into port_driver.so)

## Verification

### Crash repro + fix confirmation (isolated)
- Reproduced the crash on an EC2 instance with a live Greengrass Nucleus IPC socket
- Captured the core dump and confirmed the crash backtrace: `s_onConnectionSetup -> MessageAmendment::~MessageAmendment -> ByteBufDelete -> aws_byte_buf_clean_up -> SIGSEGV`
- Rebuilt `port_driver.so`/`write_config` against SDK v1.39.0, ran the same test: no crash, clean IPC error handling

### Full deployment verification (real device)
Deployed the fixed EMQX 2.0.4 image alongside `aws.greengrass.clientdevices.Auth` 2.5.7 on a fully-provisioned Greengrass Nucleus core device (real IoT thing, real deployment via CreateDeployment/IoT jobs):
- Deployment **SUCCEEDED**, dependency resolution between EMQX and CDA worked correctly
- EMQX container ran stable for several minutes with no crash/restart (previously crashed within ~3s every time)
- Port driver completed live IPC round-trips against CDA using the renamed `GetResult()` API (config/authorization/listener/log/plugin load all "ok")
- TCP listener (`enable_authn:false`): client connect succeeded, no `error_from_driver`, EMQX ACL correctly enforced
- SSL/mTLS listener: started cleanly, correctly rejects clients without valid certs, no crash

No regressions observed in CDA or the Nucleus IPC contract.

Fixes V2286958564
